### PR TITLE
Add more Rx semantic operators.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactKit/SwiftTask" ~> 2.4.0
+github "ReactKit/SwiftTask" ~> 2.5.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactKit/SwiftTask" ~> 2.5.0
+github "ReactKit/SwiftTask" ~> 2.5.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "duemunk/Async" "32cec7ee89d6f1a39b10f2f69d91640ba3416eca"
 github "ReactKit/SwiftState" "1.1.1"
-github "ReactKit/SwiftTask" "2.4.0"
+github "ReactKit/SwiftTask" "2.5.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "duemunk/Async" "32cec7ee89d6f1a39b10f2f69d91640ba3416eca"
 github "ReactKit/SwiftState" "1.1.1"
-github "ReactKit/SwiftTask" "2.5.0"
+github "ReactKit/SwiftTask" "2.5.1"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-ReactKit
+<img src="https://avatars3.githubusercontent.com/u/8986128" width="36" height="36"> ReactKit
 ========
 
 Swift Reactive Programming.
-
-[Introducing ReactKit // Speaker Deck](https://speakerdeck.com/inamiy/introducing-reactkit)
 
 
 ## How to install
@@ -13,7 +11,7 @@ See [Wiki page](https://github.com/ReactKit/ReactKit/wiki/How-to-install).
 
 ## Example
 
-(For UI Demo, please see [ReactKit/ReactKitCatalog](https://github.com/ReactKit/ReactKitCatalog))
+For UI Demo, please see [ReactKit/ReactKitCatalog](https://github.com/ReactKit/ReactKitCatalog).
 
 ### Key-Value Observing
 
@@ -106,37 +104,57 @@ self.buttonEnablingSignal = anyTextSignal.map { (values, changedValue) -> NSNumb
 (self.okButton, "enabled") <~ self.buttonEnablingSignal!
 ```
 
-For more examples, please see XCTest & Demo App.
+For more examples, please see XCTestCases.
 
 
 ## How it works
 
-ReactKit is just a bunch of Cocoa helpers over powerful [SwiftTask](https://github.com/inamiy/SwiftTask) (Promise library) as a basis.
+ReactKit is based on powerful [SwiftTask](https://github.com/ReactKit/SwiftTask) (JavaScript Promise-like) library, allowing to deliver multiple events (KVO, NSNotification, Target-Action, etc) continuously over time using its `progress` feature (`<~` operator in ReactKit).
 
-By taking special care of retaining flow, `ReactKit.Signal<T>` will seamlessly become a subclass of `SwiftTask.Task<T, T, NSError>`, and by using `task.progress()` interface (`<~` operator in ReactKit), `signal` will be able to send the underlying Cocoa events (KVO, NSNotification, etc) continuously over time.
+Unlike many Reactive Extensions (Rx) libraries including [ReactiveCocoa](https://github.com/ReactiveCocoa/ReactiveCocoa) which has a basic concept of "hot" and "cold" signals, ReactKit gracefully integrated them into one **hot + paused (lazy) signal** `Signal<T>` class as well as **not adopting the concept of Disposable** but using `signal.cancel()` feature instead.
 
-Also, because `signal` can also behave like Promise, it can be chained by `then()` to connect asynchronous tasks in series, so there are much less codes & methods to remember comparing to our great pioneer framework [ReactiveCocoa](https://github.com/ReactiveCocoa/ReactiveCocoa) and many other ReactiveExtension-frameworks.
+Also in ReactKit, Rx's `signal.subscribe(onNext, onError, onComplete)` method is interpreted as `signal.progress()` (`<~`) and `signal.then()`/`success()`/`failure()` separately. When they are called on needs, they will start lazy evaluation.
 
 
-## Signal Operations
+## Methods
+
+### Signal Operations
 
 - Instance Methods
   - `filter(f: T -> Bool)`
   - `filter2(f: (old: T?, new: T) -> Bool)`
   - `map(f: T -> U)`
-  - `map(f: T -> Signal<U>)` (a.k.a Rx.flatMap)
+  - `flatMap(f: T -> Signal<U>)`
   - `map2(f: (old: T?, new: T) -> U)`
-  - `map(accumulate:accumulateClosure:)` (a.k.a Rx.scan)
+  - `mapAccumulate(initialValue, accumulator)` (alias: `scan`)
   - `take(count)`
-  - `take(until: Signal)`
+  - `takeUntil(signal)`
   - `skip(count)`
-  - `skip(until: Signal)`
+  - `skipUntil(signal)`
+  - `merge(signal)`
+  - `concat(signal)`
+  - `startWith(initialValue)`
+  - `zip(signal)`
   - `buffer(count)`
-  - `buffer(trigger: Signal)`
+  - `bufferBy(signal)`
+  - `delay(timeInterval)`
   - `throttle(timeInterval)`
   - `debounce(timeInterval)`
 - Class Methods
-  - `any(signals)`
+  - `merge(signals)`
+  - `merge2(signals)` (generalized method for `merge` & `combineLatest`)
+  - `combineLatest(signals)`
+  - `concat(signals)`
+  - `zip(signals)`
+
+### Helpers
+
+- `asSignal(ValueType)` (WARNING: currently works for non-Optional only)
+- `Signal.once(value)` (alias: `just`)
+- `Signal.never()`
+- `Signal.fulfilled()` (alias: `empty`)
+- `Signal.rejected()` (alias: `error`)
+- `Signal(values:)` (a.k.a Rx.fromArray)
 
 
 ## Dependencies
@@ -145,6 +163,11 @@ Also, because `signal` can also behave like Promise, it can be chained by `then(
 - [SwiftState](https://github.com/ReactKit/SwiftState)
 
 
+## References
+
+- [Introducing ReactKit // Speaker Deck](https://speakerdeck.com/inamiy/introducing-reactkit) (ver 0.3.0)
+
+
 ## Licence
 
-[MIT](https://github.com/inamiy/ReactKit/blob/master/LICENSE)
+[MIT](https://github.com/ReactKit/ReactKit/blob/master/LICENSE)

--- a/ReactKit.xcodeproj/project.pbxproj
+++ b/ReactKit.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		4875886319E4D95A00828AD0 /* UIControl+Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4875885F19E4D95A00828AD0 /* UIControl+Signal.swift */; };
 		4875886419E4D95A00828AD0 /* UIGestureRecognizer+Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4875886019E4D95A00828AD0 /* UIGestureRecognizer+Signal.swift */; };
 		4875886519E4D95A00828AD0 /* UITextField+Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4875886119E4D95A00828AD0 /* UITextField+Signal.swift */; };
+		4890AA901A5B70650028586C /* Signal+Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4890AA8F1A5B70650028586C /* Signal+Conversion.swift */; };
+		4890AA911A5B70650028586C /* Signal+Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4890AA8F1A5B70650028586C /* Signal+Conversion.swift */; };
 		48DDE7721A0C41A300125F36 /* NSObject+Own.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48DDE7711A0C41A300125F36 /* NSObject+Own.swift */; };
 		48DDE7731A0C41A300125F36 /* NSObject+Own.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48DDE7711A0C41A300125F36 /* NSObject+Own.swift */; };
 		48FD5B3C19E51E7100913946 /* UIBarButtonItem+Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FD5B3B19E51E7100913946 /* UIBarButtonItem+Signal.swift */; };
@@ -79,6 +81,7 @@
 		4875885F19E4D95A00828AD0 /* UIControl+Signal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIControl+Signal.swift"; sourceTree = "<group>"; };
 		4875886019E4D95A00828AD0 /* UIGestureRecognizer+Signal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIGestureRecognizer+Signal.swift"; sourceTree = "<group>"; };
 		4875886119E4D95A00828AD0 /* UITextField+Signal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITextField+Signal.swift"; sourceTree = "<group>"; };
+		4890AA8F1A5B70650028586C /* Signal+Conversion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Signal+Conversion.swift"; sourceTree = "<group>"; };
 		48DDE7711A0C41A300125F36 /* NSObject+Own.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+Own.swift"; sourceTree = "<group>"; };
 		48FD5B3B19E51E7100913946 /* UIBarButtonItem+Signal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+Signal.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -162,6 +165,7 @@
 			children = (
 				1FED88FD19C1EB120065658B /* ReactKit.h */,
 				1FED895C19C1EBD60065658B /* Signal.swift */,
+				4890AA8F1A5B70650028586C /* Signal+Conversion.swift */,
 				1F8C3AAA1A2D8614000D9CF8 /* Error.swift */,
 				1F79710E19E414F70067A4C4 /* Foundation */,
 				4875885D19E4D95A00828AD0 /* UIKit */,
@@ -408,6 +412,7 @@
 				4875885B19E4D94800828AD0 /* TargetAction.swift in Sources */,
 				48DDE7721A0C41A300125F36 /* NSObject+Own.swift in Sources */,
 				4875885519E4D94800828AD0 /* KVO.swift in Sources */,
+				4890AA901A5B70650028586C /* Signal+Conversion.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -432,6 +437,7 @@
 				4875885A19E4D94800828AD0 /* NSObject+Deinit.swift in Sources */,
 				4875886319E4D95A00828AD0 /* UIControl+Signal.swift in Sources */,
 				1FED896219C1EBD60065658B /* Signal.swift in Sources */,
+				4890AA911A5B70650028586C /* Signal+Conversion.swift in Sources */,
 				1F8C3AAC1A2D8614000D9CF8 /* Error.swift in Sources */,
 				4875885C19E4D94800828AD0 /* TargetAction.swift in Sources */,
 				4875885619E4D94800828AD0 /* KVO.swift in Sources */,

--- a/ReactKit/Error.swift
+++ b/ReactKit/Error.swift
@@ -17,7 +17,7 @@ public enum ReactKitError: Int
     case CancelledByUpstream = 2
     case CancelledByTriggerSignal = 3
     case CancelledByInternalSignal = 4
-
+    
     case RejectedByInternalTask = 1000
 }
 

--- a/ReactKit/Error.swift
+++ b/ReactKit/Error.swift
@@ -16,6 +16,9 @@ public enum ReactKitError: Int
     case CancelledByDeinit = 1
     case CancelledByUpstream = 2
     case CancelledByTriggerSignal = 3
+    case CancelledByInternalSignal = 4
+
+    case RejectedByInternalTask = 1000
 }
 
 /// helper

--- a/ReactKit/Foundation/KVO.swift
+++ b/ReactKit/Foundation/KVO.swift
@@ -25,7 +25,7 @@ public extension NSObject
                 configure.cancel = { observer.stop() }
             }
             
-        }.name("KVO-\(NSStringFromClass(self.dynamicType))-\(keyPath)").take(until: self.deinitSignal)
+        }.name("KVO-\(NSStringFromClass(self.dynamicType))-\(keyPath)").takeUntil(self.deinitSignal)
     }
 }
 

--- a/ReactKit/Foundation/NSObject+Deinit.swift
+++ b/ReactKit/Foundation/NSObject+Deinit.swift
@@ -29,7 +29,7 @@ public extension NSObject
         if signal == nil {
             signal = Signal<AnyObject?> { (progress, fulfill, reject, configure) in
                 // do nothing
-            }.name("deinitSignal")
+            }.name("\(NSStringFromClass(self.dynamicType))-deinitSignal")
             
             #if DEBUG
                 signal?.then { value, errorInfo -> Void in

--- a/ReactKit/Foundation/NSTimer+Signal.swift
+++ b/ReactKit/Foundation/NSTimer+Signal.swift
@@ -16,6 +16,10 @@ public extension NSTimer
             
             let target = _TargetActionProxy { (self_: AnyObject?) in
                 progress(map(self_ as? NSTimer))
+                
+                if !repeats {
+                    fulfill(map(self_ as? NSTimer))
+                }
             }
             
             var timer: NSTimer?

--- a/ReactKit/Foundation/Notification.swift
+++ b/ReactKit/Foundation/Notification.swift
@@ -43,7 +43,7 @@ public extension NSNotificationCenter
                 }
             }
             
-        }.name("NSNotification-\(notificationName)").take(until: self.deinitSignal)
+        }.name("NSNotification-\(notificationName)").takeUntil(self.deinitSignal)
     }
 }
 

--- a/ReactKit/Signal+Conversion.swift
+++ b/ReactKit/Signal+Conversion.swift
@@ -11,6 +11,20 @@ import SwiftTask
 
 public extension Signal
 {
+    ///
+    /// FIXME:
+    /// Currently in Swift 1.1, `signal.asSignal(U)` is only available
+    /// when both `T` of `signal: Signal<T>` and `U` are non-Optional.
+    /// Otherwise, "Swift dynamic cast failure" will occur (bug?).
+    ///
+    /// To work around this issue, use `map { $0 as U? }` directly
+    /// to convert from `Signal<T?>` to `Signal<U?>` as follows:
+    ///
+    /// ```
+    /// let signal: Signal<AnyObject?> = ...`
+    /// let convertedSignal: Signal<String?> = signal.map { $0 as String? }
+    /// ```
+    ///
     public func asSignal<U>(type: U.Type) -> Signal<U>
     {
         return self.map { $0 as U }

--- a/ReactKit/Signal+Conversion.swift
+++ b/ReactKit/Signal+Conversion.swift
@@ -41,7 +41,19 @@ public extension Signal
                     }
                 }
             }
-            return
+            
+            configure.pause = {
+                task.pause()
+                return
+            }
+            configure.resume = {
+                task.resume()
+                return
+            }
+            configure.cancel = {
+                task.cancel()
+                return
+            }
         }
     }
     
@@ -76,7 +88,19 @@ public extension Signal
                     }
                 }
             }
-            return
+            
+            configure.pause = {
+                task.pause()
+                return
+            }
+            configure.resume = {
+                task.resume()
+                return
+            }
+            configure.cancel = {
+                task.cancel()
+                return
+            }
         }
     }
     

--- a/ReactKit/Signal+Conversion.swift
+++ b/ReactKit/Signal+Conversion.swift
@@ -35,34 +35,34 @@ public extension Signal
     //--------------------------------------------------
     
     /// creates once (progress once & fulfill) signal
-    public class func once(value: T, paused: Bool = true) -> Signal<T>
+    public class func once(value: T) -> Signal<T>
     {
-        return Signal(paused: paused) { progress, fulfill, reject, configure in
+        return Signal { progress, fulfill, reject, configure in
             progress(value)
             fulfill()
         }.name("OnceSignal")
     }
     
     /// creates never (no progress & fulfill & reject) signal
-    public class func never(paused: Bool = true) -> Signal<T>
+    public class func never() -> Signal<T>
     {
-        return Signal(paused: paused) { progress, fulfill, reject, configure in
+        return Signal { progress, fulfill, reject, configure in
             // do nothing
         }.name("NeverSignal")
     }
     
     /// creates empty (fulfilled without any progress) signal
-    public class func fulfilled(paused: Bool = true) -> Signal<T>
+    public class func fulfilled() -> Signal<T>
     {
-        return Signal(paused: paused) { progress, fulfill, reject, configure in
+        return Signal { progress, fulfill, reject, configure in
             fulfill()
         }.name("FulfilledSignal")
     }
     
     /// creates error (rejected) signal
-    public class func rejected(error: NSError, paused: Bool = true) -> Signal<T>
+    public class func rejected(error: NSError) -> Signal<T>
     {
-        return Signal(paused: paused) { progress, fulfill, reject, configure in
+        return Signal { progress, fulfill, reject, configure in
             reject(error)
         }.name("RejectedSignal")
     }
@@ -166,20 +166,20 @@ public extension Signal
     //--------------------------------------------------
     
     /// alias for `Signal.fulfilled()`
-    public class func just(value: T, paused: Bool = true) -> Signal<T>
+    public class func just(value: T) -> Signal<T>
     {
-        return self.once(value, paused: paused)
+        return self.once(value)
     }
     
     /// alias for `Signal.fulfilled()`
-    public class func empty(paused: Bool = true) -> Signal<T>
+    public class func empty() -> Signal<T>
     {
-        return self.fulfilled(paused: paused)
+        return self.fulfilled()
     }
     
     /// alias for `Signal.rejected()`
-    public class func error(error: NSError, paused: Bool = true) -> Signal<T>
+    public class func error(error: NSError) -> Signal<T>
     {
-        return self.rejected(error, paused: paused)
+        return self.rejected(error)
     }
 }

--- a/ReactKit/Signal+Conversion.swift
+++ b/ReactKit/Signal+Conversion.swift
@@ -16,6 +16,47 @@ public extension Signal
         return self.map { $0 as U }
     }
     
+    //--------------------------------------------------
+    /// MARK: - From Values
+    //--------------------------------------------------
+    
+    /// creates once (progress once & fulfill) signal
+    public class func once(value: T, paused: Bool = true) -> Signal<T>
+    {
+        return Signal(paused: paused) { progress, fulfill, reject, configure in
+            progress(value)
+            fulfill()
+        }.name("OnceSignal")
+    }
+    
+    /// creates never (no progress & fulfill & reject) signal
+    public class func never(paused: Bool = true) -> Signal<T>
+    {
+        return Signal(paused: paused) { progress, fulfill, reject, configure in
+            // do nothing
+        }.name("NeverSignal")
+    }
+    
+    /// creates empty (fulfilled without any progress) signal
+    public class func fulfilled(paused: Bool = true) -> Signal<T>
+    {
+        return Signal(paused: paused) { progress, fulfill, reject, configure in
+            fulfill()
+        }.name("FulfilledSignal")
+    }
+    
+    /// creates error (rejected) signal
+    public class func rejected(error: NSError, paused: Bool = true) -> Signal<T>
+    {
+        return Signal(paused: paused) { progress, fulfill, reject, configure in
+            reject(error)
+        }.name("RejectedSignal")
+    }
+    
+    //--------------------------------------------------
+    /// MARK: - From SwiftTask
+    //--------------------------------------------------
+    
     ///
     /// Converts `Task<P, V, E>` to `Signal<V>`.
     ///
@@ -54,7 +95,8 @@ public extension Signal
                 task.cancel()
                 return
             }
-        }
+            
+        }.name("Signal.fromTask")
     }
     
     ///
@@ -101,7 +143,29 @@ public extension Signal
                 task.cancel()
                 return
             }
-        }
+            
+        }.name("Signal.fromProgressTask")
     }
     
+    //--------------------------------------------------
+    // MARK: - Rx Semantics
+    //--------------------------------------------------
+    
+    /// alias for `Signal.fulfilled()`
+    public class func just(value: T, paused: Bool = true) -> Signal<T>
+    {
+        return self.once(value, paused: paused)
+    }
+    
+    /// alias for `Signal.fulfilled()`
+    public class func empty(paused: Bool = true) -> Signal<T>
+    {
+        return self.fulfilled(paused: paused)
+    }
+    
+    /// alias for `Signal.rejected()`
+    public class func error(error: NSError, paused: Bool = true) -> Signal<T>
+    {
+        return self.rejected(error, paused: paused)
+    }
 }

--- a/ReactKit/Signal+Conversion.swift
+++ b/ReactKit/Signal+Conversion.swift
@@ -1,0 +1,83 @@
+//
+//  Signal+Conversion.swift
+//  ReactKit
+//
+//  Created by Yasuhiro Inami on 2015/01/08.
+//  Copyright (c) 2015年 Yasuhiro Inami. All rights reserved.
+//
+
+import Foundation
+import SwiftTask
+
+public extension Signal
+{
+    public func asSignal<U>(type: U.Type) -> Signal<U>
+    {
+        return self.map { $0 as U }
+    }
+    
+    ///
+    /// Converts `Task<P, V, E>` to `Signal<V>`.
+    ///
+    /// Task's fulfilled-value (`task.value`) will be interpreted as signal's progress-value (`signal.progress`),
+    /// and any task's progress-values (`task.progress`) will be discarded.
+    ///
+    public class func fromTask<P, V, E>(task: Task<P, V, E>) -> Signal<V>
+    {
+        return Signal<V> { progress, fulfill, reject, configure in
+            
+            task.then { value, errorInfo -> Void in
+                if let value = value {
+                    progress(value)
+                    fulfill(value)
+                }
+                else if let errorInfo = errorInfo {
+                    if let error = errorInfo.error as? NSError {
+                        reject(error)
+                    }
+                    else {
+                        let error = _RKError(.RejectedByInternalTask, "`task` is rejected/cancelled while `Signal.fromTask(task)`.")
+                        reject(error)
+                    }
+                }
+            }
+            return
+        }
+    }
+    
+    ///
+    /// Converts `Task<P, V, E>` to `Signal<(P?, V?)>`.
+    ///
+    /// Both task's progress-values (`task.progress`) and fulfilled-value (`task.value`) 
+    /// will be interpreted as signal's progress-value (`signal.progress`),
+    /// so unlike `Signal.fromTask(_:)`, all `task.progress` will NOT be discarded.
+    ///
+    public class func fromProgressTask<P, V, E>(task: Task<P, V, E>) -> Signal<(P?, V?)>
+    {
+        return Signal<(P?, V?)> { progress, fulfill, reject, configure in
+            
+            task.progress { [weak task] _, progressValue in
+                
+                progress(progressValue, nil)
+                
+            }.then { [weak task] value, errorInfo -> Void in
+                
+                if let value = value {
+                    progress(task!.progress, value)
+                    fulfill(task!.progress, value)
+                }
+                else if let errorInfo = errorInfo {
+                    if let error = errorInfo.error as? NSError {
+                        reject(error)
+                    }
+                    else {
+                        let error = _RKError(.RejectedByInternalTask, "`task` is rejected/cancelled while `Signal.fromProgressTask(task)`.")
+                        reject(error)
+                    }
+                }
+            }
+            return
+        }
+    }
+    
+}

--- a/ReactKit/Signal.swift
+++ b/ReactKit/Signal.swift
@@ -221,8 +221,7 @@ public extension Signal
     }
     
     /// map using newValue only & bind to transformed Signal
-    /// a.k.a `Rx.flatMap()`
-    public func map<U>(transformToSignal: T -> Signal<U>) -> Signal<U>
+    public func flatMap<U>(transform: T -> Signal<U>) -> Signal<U>
     {
         return Signal<U> { progress, fulfill, reject, configure in
             
@@ -230,26 +229,24 @@ public extension Signal
             var innerSignals: [Signal<U>] = []
             
             self.progress { (_, progressValue: T) in
-                let innerSignal = transformToSignal(progressValue)
+                let innerSignal = transform(progressValue)
                 innerSignals += [innerSignal]
                 
                 innerSignal.progress { (_, progressValue: U) in
                     progress(progressValue)
                 }
-                return
             }.success { (value: T) -> Void in
-                let innerSignal = transformToSignal(value)
+                let innerSignal = transform(value)
                 innerSignals += [innerSignal]
                 
                 innerSignal.progress { (_, progressValue: U) in
                     fulfill(progressValue)
                 }
-                return
             }
             
             _bind(nil, reject, configure, self)
             
-        }.name("\(self.name)-map(signal)")
+            }.name("\(self.name)-flatMap")
     }
     
     /// map using (oldValue, newValue)

--- a/ReactKit/Signal.swift
+++ b/ReactKit/Signal.swift
@@ -689,8 +689,9 @@ public extension Signal
     public class func combineLatest<U>(signals: [Signal<U>]) -> Signal<[T]>
     {
         return self.merge2(signals).filter { values, _ in
-            let areAllNonNil = values.reduce(true) { (previous, value) -> Bool in
-                return previous && (value != nil)
+            var areAllNonNil = true
+            for value in values {
+                if value == nil { areAllNonNil = false; break }
             }
             return areAllNonNil
         }.map { values, _ in values.map { $0! } }
@@ -767,8 +768,9 @@ public extension Signal
                     
                     storedValuesArray[i] += [progressValue as T]
                     
-                    let canProgress = storedValuesArray.reduce(true) { (previous, storedValues) -> Bool in
-                        return previous && (storedValues.count > 0)
+                    var canProgress: Bool = true
+                    for storedValues in storedValuesArray {
+                        if storedValues.count == 0 { canProgress = false; break }
                     }
                     
                     if canProgress {

--- a/ReactKit/Signal.swift
+++ b/ReactKit/Signal.swift
@@ -278,7 +278,7 @@ public extension Signal
     
     /// map using (accumulatedValue, newValue)
     /// a.k.a `Rx.scan()`
-    public func map<U>(accumulate initialValue: U, _ accumulateClosure: (accumulatedValue: U, newValue: T) -> U) -> Signal<U>
+    public func mapAccumulate<U>(initialValue: U, _ accumulateClosure: (accumulatedValue: U, newValue: T) -> U) -> Signal<U>
     {
         return Signal<U> { progress, fulfill, reject, configure in
             
@@ -702,9 +702,9 @@ public extension Signal
 /// (TODO: move to new file, but doesn't work in Swift 1.1. ERROR = ld: symbol(s) not found for architecture x86_64)
 public extension Signal
 {
-    public func scan<U>(initial initialValue: U, _ accumulateClosure: (accumulatedValue: U, newValue: T) -> U) -> Signal<U>
+    public func scan<U>(initialValue: U, _ accumulateClosure: (accumulatedValue: U, newValue: T) -> U) -> Signal<U>
     {
-        return self.map(accumulate: initialValue, accumulateClosure)
+        return self.mapAccumulate(initialValue, accumulateClosure)
     }
 
     public class func combineLatest<U>(signals: [Signal<U>]) -> Signal<[T?]>

--- a/ReactKit/Signal.swift
+++ b/ReactKit/Signal.swift
@@ -699,11 +699,7 @@ public extension Signal
     
     public class func concat<U>(signals: [Signal<U>]) -> Signal<T>
     {
-        precondition(signals.count > 0)
-        
-        if signals.count == 1 {
-            return signals.first!.asSignal(T)
-        }
+        precondition(signals.count > 1)
         
         return Signal<T> { progress, fulfill, reject, configure in
             

--- a/ReactKit/Signal.swift
+++ b/ReactKit/Signal.swift
@@ -629,6 +629,21 @@ public extension Signal
     
 }
 
+/// Signal + ReactiveExtension Semantics
+/// (TODO: move to new file, but doesn't work in Swift 1.1. ERROR = ld: symbol(s) not found for architecture x86_64)
+public extension Signal
+{
+    public func scan<U>(initial initialValue: U, _ accumulateClosure: (accumulatedValue: U, newValue: T) -> U) -> Signal<U>
+    {
+        return self.map(accumulate: initialValue, accumulateClosure)
+    }
+
+    public class func combineLatest<U>(signals: [Signal<U>]) -> Signal<[T?]>
+    {
+        return self.merge2(signals).map { values, _ in values }
+    }
+}
+
 /// wrapper-class for weakifying
 internal class _SignalGroup<T>
 {

--- a/ReactKit/Signal.swift
+++ b/ReactKit/Signal.swift
@@ -320,7 +320,7 @@ public extension Signal
         }.name("\(self.name)-take(\(maxCount))")
     }
     
-    public func take<U>(until triggerSignal: Signal<U>) -> Signal
+    public func takeUntil<U>(triggerSignal: Signal<U>) -> Signal
     {
         return Signal<T> { [weak triggerSignal] progress, fulfill, reject, configure in
             
@@ -331,7 +331,7 @@ public extension Signal
             }
 
             let triggerSignalName = triggerSignal!.name
-            let cancelError = _RKError(.CancelledByTriggerSignal, "Signal=\(signalName) is cancelled by take(until: \(triggerSignalName)).")
+            let cancelError = _RKError(.CancelledByTriggerSignal, "Signal=\(signalName) is cancelled by takeUntil(\(triggerSignalName)).")
             
             triggerSignal?.progress { [weak self] (_, progressValue: U) in
                 if let self_ = self {
@@ -349,7 +349,7 @@ public extension Signal
             
             _bind(fulfill, reject, configure, self)
             
-        }.name("\(self.name)-take(until:)")
+        }.name("\(self.name)-takeUntil")
     }
     
     public func skip(skipCount: Int) -> Signal

--- a/ReactKit/Signal.swift
+++ b/ReactKit/Signal.swift
@@ -452,7 +452,7 @@ public extension Signal
         }.name("\(self.name)-buffer")
     }
     
-    public func buffer<U>(trigger triggerSignal: Signal<U>) -> Signal<[T]>
+    public func bufferBy<U>(triggerSignal: Signal<U>) -> Signal<[T]>
     {
         return Signal<[T]> { progress, fulfill, reject, configure in
             

--- a/ReactKit/Signal.swift
+++ b/ReactKit/Signal.swift
@@ -686,6 +686,16 @@ public extension Signal
         }.name("Signal.merge2")
     }
     
+    public class func combineLatest<U>(signals: [Signal<U>]) -> Signal<[T]>
+    {
+        return self.merge2(signals).filter { values, _ in
+            let areAllNonNil = values.reduce(true) { (previous, value) -> Bool in
+                return previous && (value != nil)
+            }
+            return areAllNonNil
+        }.map { values, _ in values.map { $0! } }
+    }
+    
     public class func concat<U>(signals: [Signal<U>]) -> Signal<T>
     {
         precondition(signals.count > 0)
@@ -803,11 +813,6 @@ public extension Signal
     public func scan<U>(initialValue: U, _ accumulateClosure: (accumulatedValue: U, newValue: T) -> U) -> Signal<U>
     {
         return self.mapAccumulate(initialValue, accumulateClosure)
-    }
-
-    public class func combineLatest<U>(signals: [Signal<U>]) -> Signal<[T?]>
-    {
-        return self.merge2(signals).map { values, _ in values }
     }
 }
 

--- a/ReactKit/Signal.swift
+++ b/ReactKit/Signal.swift
@@ -19,28 +19,24 @@ public class Signal<T>: Task<T, Void, NSError>
     /// Creates a new signal (event-delivery-pipeline over time).
     /// Synonym of "stream", "observable", etc.
     ///
-    /// :param: paused Flag to invoke `initClosure` immediately or not. If `paused = true`, signal's initial state will be `.Paused` (lazy, similar to "cold signal") and needs to `resume()` in order to start `.Running`. If `paused = false`, `initClosure` will be invoked immediately.
-    ///
     /// :param: initClosure Closure to define returning signal's behavior. Inside this closure, `configure.pause`/`resume`/`cancel` should capture inner logic (player) object. See also comment in `SwiftTask.Task.init()`.
     ///
     /// :returns: New Signal.
     /// 
-    public init(paused: Bool, initClosure: Task<T, Void, NSError>.InitClosure)
+    public init(initClosure: Task<T, Void, NSError>.InitClosure)
     {
-        // NOTE: set weakified=true to avoid "(inner) player -> signal" retaining
-        super.init(weakified: true, paused: paused, initClosure: initClosure)
+        //
+        // NOTE: 
+        // - set `weakified = true` to avoid "(inner) player -> signal" retaining
+        // - set `paused = true` for lazy evaluation (similar to "cold signal")
+        //
+        super.init(weakified: true, paused: true, initClosure: initClosure)
         
         self.name = "DefaultSignal"
         
         #if DEBUG
             println("[init] \(self)")
         #endif
-    }
-    
-    /// creates paused signal
-    public convenience init(initClosure: Task<T, Void, NSError>.InitClosure)
-    {
-        self.init(paused: true, initClosure: initClosure)
     }
     
     // TODO: move this to Signal+Conversion.swift (undefined symbols error in Swift 1.1)
@@ -53,7 +49,7 @@ public class Signal<T>: Task<T, Void, NSError>
     ///
     public convenience init<S: SequenceType where S.Generator.Element == T>(values: S)
     {
-        self.init(paused: true, initClosure: { progress, fulfill, reject, configure in
+        self.init(initClosure: { progress, fulfill, reject, configure in
             var generator = values.generate()
             while let value: T = generator.next() {
                 progress(value)

--- a/ReactKit/Signal.swift
+++ b/ReactKit/Signal.swift
@@ -370,7 +370,7 @@ public extension Signal
         }.name("\(self.name)-skip(\(skipCount))")
     }
     
-    public func skip<U>(until triggerSignal: Signal<U>) -> Signal
+    public func skipUntil<U>(triggerSignal: Signal<U>) -> Signal
     {
         return Signal<T> { [weak triggerSignal] progress, fulfill, reject, configure in
             
@@ -394,7 +394,7 @@ public extension Signal
             
             _bind(fulfill, reject, configure, self)
             
-        }.name("\(self.name)-skip(until:)")
+        }.name("\(self.name)-skipUntil")
     }
     
     public func merge(signal: Signal<T>) -> Signal<T>

--- a/ReactKit/Signal.swift
+++ b/ReactKit/Signal.swift
@@ -517,7 +517,7 @@ public extension Signal
 // Multiple Signal Operations
 public extension Signal
 {
-    // TODO: using variadic parameters didn't work when `signal.merge(...)` invoking `Signal.merge(...)`. Swift bug?
+    // TODO: when using variadic parameters, `signal.merge(...)` can't find `Signal.merge(...)` to invoke. Swift bug?
     
     ///
     /// Merges multiple signals (`Signal<U>`) into single signal, with force-casting to `Signal<T>`.

--- a/ReactKit/UIKit/UIBarButtonItem+Signal.swift
+++ b/ReactKit/UIKit/UIBarButtonItem+Signal.swift
@@ -42,7 +42,7 @@ public extension UIBarButtonItem
                 removeTargetAction()
             }
             
-        }.name("\(NSStringFromClass(self.dynamicType))").take(until: self.deinitSignal)
+        }.name("\(NSStringFromClass(self.dynamicType))").takeUntil(self.deinitSignal)
     }
     
     public func signal<T>(mappedValue: T) -> Signal<T>

--- a/ReactKit/UIKit/UIControl+Signal.swift
+++ b/ReactKit/UIKit/UIControl+Signal.swift
@@ -52,6 +52,6 @@ public extension UIControl
                 }
             }
             
-        }.name("\(NSStringFromClass(self.dynamicType))-\(controlEvents)").take(until: self.deinitSignal)
+        }.name("\(NSStringFromClass(self.dynamicType))-\(controlEvents)").takeUntil(self.deinitSignal)
     }
 }

--- a/ReactKit/UIKit/UIGestureRecognizer+Signal.swift
+++ b/ReactKit/UIKit/UIGestureRecognizer+Signal.swift
@@ -35,6 +35,6 @@ public extension UIGestureRecognizer
                 }
             }
             
-        }.name("\(NSStringFromClass(self.dynamicType))").take(until: self.deinitSignal)
+        }.name("\(NSStringFromClass(self.dynamicType))").takeUntil(self.deinitSignal)
     }
 }

--- a/ReactKit/UIKit/UITextField+Signal.swift
+++ b/ReactKit/UIKit/UITextField+Signal.swift
@@ -17,6 +17,6 @@ public extension UITextField
                 return sender.text
             }
             return nil
-        }.take(until: self.deinitSignal)
+        }.takeUntil(self.deinitSignal)
     }
 }

--- a/ReactKitTests/DeinitSignalTests.swift
+++ b/ReactKitTests/DeinitSignalTests.swift
@@ -22,7 +22,7 @@ class DeinitSignalTests: _TestCase
         // always use `weak` for deinitSignal to avoid it being captured by current execution context
         weak var deinitSignal: Signal<AnyObject?>? = shortLivedObject!.deinitSignal
         
-        let obj1Signal = KVO.signal(obj1, "value").take(until: deinitSignal!)
+        let obj1Signal = KVO.signal(obj1, "value").takeUntil(deinitSignal!)
         
         // REACT
         (obj2, "value") <~ obj1Signal
@@ -62,7 +62,7 @@ class DeinitSignalTests: _TestCase
         // NOTE: `weak` is not used for this test
         var deinitSignal: Signal<AnyObject?>? = shortLivedObject!.deinitSignal
         
-        let obj1Signal = KVO.signal(obj1, "value").take(until: deinitSignal!)
+        let obj1Signal = KVO.signal(obj1, "value").takeUntil(deinitSignal!)
         
         // REACT
         (obj2, "value") <~ obj1Signal

--- a/ReactKitTests/KVOTests.swift
+++ b/ReactKitTests/KVOTests.swift
@@ -331,7 +331,7 @@ class KVOTests: _TestCase
     }
     
     /// a.k.a `Rx.scan`
-    func testKVO_map_accumulate()
+    func testKVO_mapAccumulate()
     {
         let expect = self.expectationWithDescription(__FUNCTION__)
         
@@ -484,7 +484,7 @@ class KVOTests: _TestCase
         self.wait()
     }
     
-    func testKVO_take_until()
+    func testKVO_takeUntil()
     {
         let expect = self.expectationWithDescription(__FUNCTION__)
         
@@ -571,7 +571,7 @@ class KVOTests: _TestCase
         self.wait()
     }
     
-    func testKVO_skip_until()
+    func testKVO_skipUntil()
     {
         let expect = self.expectationWithDescription(__FUNCTION__)
         
@@ -616,7 +616,7 @@ class KVOTests: _TestCase
         self.wait()
     }
     
-    func testBuffer()
+    func testKVO_buffer()
     {
         let expect = self.expectationWithDescription(__FUNCTION__)
         
@@ -668,7 +668,7 @@ class KVOTests: _TestCase
         self.wait()
     }
     
-    func testBuffer_trigger()
+    func testKVO_bufferBy()
     {
         let expect = self.expectationWithDescription(__FUNCTION__)
         
@@ -676,7 +676,7 @@ class KVOTests: _TestCase
         let trigger = MyObject()
         
         let triggerSignal = KVO.signal(trigger, "value")
-        let signal: Signal<[AnyObject?]> = KVO.signal(obj1, "value").buffer(trigger: triggerSignal)
+        let signal: Signal<[AnyObject?]> = KVO.signal(obj1, "value").bufferBy(triggerSignal)
         
         var result: String? = "no result"
         

--- a/ReactKitTests/KVOTests.swift
+++ b/ReactKitTests/KVOTests.swift
@@ -232,8 +232,7 @@ class KVOTests: _TestCase
         self.wait()
     }
     
-    /// a.k.a `Rx.flatMap`
-    func testKVO_map_signal()
+    func testKVO_flatMap()
     {
         // NOTE: this is async test
         if !self.isAsync { return }
@@ -244,7 +243,7 @@ class KVOTests: _TestCase
         let obj2 = MyObject()
         
         // NOTE: `mapClosure` is returning Signal
-        let signal = KVO.signal(obj1, "value").map { (value: AnyObject?) -> Signal<AnyObject?> in
+        let signal = KVO.signal(obj1, "value").flatMap { (value: AnyObject?) -> Signal<AnyObject?> in
             // delay sending value for 0.01 sec
             return NSTimer.signal(timeInterval: 0.01, repeats: false) { _ in value }
         }

--- a/ReactKitTests/KVOTests.swift
+++ b/ReactKitTests/KVOTests.swift
@@ -493,7 +493,7 @@ class KVOTests: _TestCase
         let stopper = MyObject()
         
         let stoppingSignal = KVO.signal(stopper, "value")    // store stoppingSignal to live until end of runloop
-        let signal = KVO.signal(obj1, "value").take(until: stoppingSignal)
+        let signal = KVO.signal(obj1, "value").takeUntil(stoppingSignal)
         
         weak var weakSignal = signal
         
@@ -520,7 +520,7 @@ class KVOTests: _TestCase
             obj1.value = "fuga"
             
             XCTAssertEqual(obj1.value, "fuga")
-            XCTAssertEqual(obj2.value, "hoge", "obj2.value should not be updated because signal is stopped via take(until: stoppingSignal).")
+            XCTAssertEqual(obj2.value, "hoge", "obj2.value should not be updated because signal is stopped via takeUntil(stoppingSignal).")
             
             expect.fulfill()
             

--- a/ReactKitTests/KVOTests.swift
+++ b/ReactKitTests/KVOTests.swift
@@ -814,7 +814,7 @@ class KVOTests: _TestCase
     
     // MARK: Multiple Signal Operations
     
-    func testKVO_any()
+    func testKVO_merge2()
     {
         let expect = self.expectationWithDescription(__FUNCTION__)
         
@@ -825,7 +825,7 @@ class KVOTests: _TestCase
         let signal1 = KVO.signal(obj1, "value")
         let signal2 = KVO.signal(obj2, "number")
         
-        var bundledSignal = Signal.any([signal1, signal2]).filter { values, changedValue in
+        var bundledSignal = Signal.merge2([signal1, signal2]).filter { values, changedValue in
             
             println("values = \(values)")
             println("changedValue = \(changedValue)")

--- a/ReactKitTests/KVOTests.swift
+++ b/ReactKitTests/KVOTests.swift
@@ -580,7 +580,7 @@ class KVOTests: _TestCase
         let stopper = MyObject()
         
         let startingSignal = KVO.signal(stopper, "value")    // store startingSignal to live until end of runloop
-        let signal = KVO.signal(obj1, "value").skip(until: startingSignal)
+        let signal = KVO.signal(obj1, "value").skipUntil(startingSignal)
         
         weak var weakSignal = signal
         
@@ -600,14 +600,14 @@ class KVOTests: _TestCase
             obj1.value = "hoge"
             
             XCTAssertEqual(obj1.value, "hoge")
-            XCTAssertEqual(obj2.value, "initial", "obj2.value should not be changed due to `skip(until:)`.")
+            XCTAssertEqual(obj2.value, "initial", "obj2.value should not be changed due to `skipUntil()`.")
             
             stopper.value = "DUMMY" // fire startingSignal
             
             obj1.value = "fuga"
             
             XCTAssertEqual(obj1.value, "fuga")
-            XCTAssertEqual(obj2.value, "fuga", "obj2.value should be updated because `startingSignal` is triggered so that `skip(until: startingSignal)` should no longer skip.")
+            XCTAssertEqual(obj2.value, "fuga", "obj2.value should be updated because `startingSignal` is triggered so that `skipUntil(startingSignal)` should no longer skip.")
             
             expect.fulfill()
             

--- a/ReactKitTests/KVOTests.swift
+++ b/ReactKitTests/KVOTests.swift
@@ -858,7 +858,11 @@ class KVOTests: _TestCase
         self.wait()
     }
     
-    /// a.k.a `Rx.combineLatest()`
+    //
+    // NOTE: 
+    // `merge2()` works like both `Rx.merge()` and `Rx.combineLatest()`.
+    // This test demonstrates `combineLatest` example.
+    //
     func testKVO_merge2()
     {
         let expect = self.expectationWithDescription(__FUNCTION__)
@@ -902,7 +906,6 @@ class KVOTests: _TestCase
         self.wait()
     }
     
-    /// a.k.a `Rx.combineLatest()`
     /// almost same as `testKVO_merge2()`
     func testKVO_combineLatest()
     {

--- a/ReactKitTests/KVOTests.swift
+++ b/ReactKitTests/KVOTests.swift
@@ -337,7 +337,7 @@ class KVOTests: _TestCase
         
         let obj1 = MyObject()
         
-        let signal = KVO.signal(obj1, "value").map(accumulate: []) { accumulatedValue, newValue -> [String] in
+        let signal = KVO.signal(obj1, "value").mapAccumulate([]) { accumulatedValue, newValue -> [String] in
             return accumulatedValue + [newValue as String]
         }
         


### PR DESCRIPTION
This pull request is an improvement for #10 (Rx semantics),
and also a **BREAKING CHANGE** to use different Task subclass 
as discussed in #12.

### Added

- [x] `fromTask` (like fromPromise)
- [x] `combineLatest`
- [x] `concat`
- [x] `startWith`
- [x] `zip`
- [x] `delay`
- [x] `once` (`just`), `fulfilled` (`empty`), `rejected` (`error`), `never`

### Renamed

- [x] `flatMap`
- [x] `mapAccumulate`, `scan` (alias)
- [x] `takeUntil`
- [x] `skipUntil`
- [x] `Signal.merge2`