### PR TITLE
Change Signal<T>'s superclass from Task<T, T, NSError> to Task<T, Void, NSError>

### DIFF
--- a/ReactKit/Foundation/NSTimer+Signal.swift
+++ b/ReactKit/Foundation/NSTimer+Signal.swift
@@ -18,7 +18,7 @@ public extension NSTimer
                 progress(map(self_ as? NSTimer))
                 
                 if !repeats {
-                    fulfill(map(self_ as? NSTimer))
+                    fulfill()
                 }
             }
             

--- a/ReactKit/Signal+Conversion.swift
+++ b/ReactKit/Signal+Conversion.swift
@@ -29,7 +29,7 @@ public extension Signal
             task.then { value, errorInfo -> Void in
                 if let value = value {
                     progress(value)
-                    fulfill(value)
+                    fulfill()
                 }
                 else if let errorInfo = errorInfo {
                     if let error = errorInfo.error as? NSError {
@@ -76,7 +76,7 @@ public extension Signal
                 
                 if let value = value {
                     progress(task!.progress, value)
-                    fulfill(task!.progress, value)
+                    fulfill()
                 }
                 else if let errorInfo = errorInfo {
                     if let error = errorInfo.error as? NSError {

--- a/ReactKitTests/KVOTests.swift
+++ b/ReactKitTests/KVOTests.swift
@@ -426,9 +426,8 @@ class KVOTests: _TestCase
         ^{ _ in progressCount++; return } <~ takeSignal
         
         // success
-        takeSignal.success { value -> Void in
+        takeSignal.success {
             successCount++
-            XCTAssertEqual(value! as String, "hoge")
         }
         
         println("*** Start ***")


### PR DESCRIPTION
This is a **BREAKING CHANGE** to disable SwiftTask's success-value-pipelining (sending `Void` instead) in ReactKit, so that internal codes will be more simpler and it will work more similar to ReactiveExtensions and many other libraries.
