### PR TITLE
KVO signals should allow nil value placeholder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ DerivedData
 *.xcuserstate
 
 Carthage/Build
+.DS_Store

--- a/ReactKit/Foundation/KVO.swift
+++ b/ReactKit/Foundation/KVO.swift
@@ -32,7 +32,10 @@ public extension NSObject
     public func startingSignal(#keyPath: String, nilValue: AnyObject? = nil) -> Signal<AnyObject?>
     {
         var initial: AnyObject? = self.valueForKeyPath(keyPath)
-        initial = (initial is NSNull) ? nilValue : initial
+        if initial is NSNull {
+            initial = nil
+        }
+        initial = initial ?? nilValue
         return self.signal(keyPath: keyPath, nilValue: nilValue).startWith(initial)
     }
     

--- a/ReactKit/Foundation/KVO.swift
+++ b/ReactKit/Foundation/KVO.swift
@@ -11,13 +11,13 @@ import Foundation
 public extension NSObject
 {
     /// creates new KVO Signal (new value only)
-    public func signal(#keyPath: String) -> Signal<AnyObject?>
+    public func signal(#keyPath: String, nilValue: AnyObject? = nil) -> Signal<AnyObject?>
     {
         return Signal { [weak self] progress, fulfill, reject, configure in
             
             if let self_ = self {
                 let observer = _KVOProxy(target: self_, keyPath: keyPath) { value, change, indexSet in
-                    progress(value)
+                    progress((value is NSNull) ? nilValue : value)
                 }
                 
                 configure.pause = { observer.stop() }
@@ -29,9 +29,10 @@ public extension NSObject
     }
     
     /// creates new KVO Signal (initial + new value)
-    public func startingSignal(#keyPath: String) -> Signal<AnyObject?>
+    public func startingSignal(#keyPath: String, nilValue: AnyObject? = nil) -> Signal<AnyObject?>
     {
-        return self.signal(keyPath: keyPath).startWith(self.valueForKeyPath(keyPath))
+        let initial: AnyObject? = self.valueForKeyPath(keyPath)
+        return self.signal(keyPath: keyPath, nilValue: nilValue).startWith((initial is NSNull) ? nilValue : initial)
     }
     
     ///
@@ -44,13 +45,13 @@ public extension NSObject
     /// let itemsProxy = model.mutableArrayValueForKey("items")
     /// itemsProxy.insertObject(newItem, atIndex: 0) // itemsSignal will send **both** `newItem` and `index`
     ///
-    public func detailedSignal(#keyPath: String) -> Signal<(AnyObject?, NSKeyValueChange, NSIndexSet?)>
+    public func detailedSignal(#keyPath: String, nilValue: AnyObject? = nil) -> Signal<(AnyObject?, NSKeyValueChange, NSIndexSet?)>
     {
         return Signal { [weak self] progress, fulfill, reject, configure in
             
             if let self_ = self {
                 let observer = _KVOProxy(target: self_, keyPath: keyPath) { value, change, indexSet in
-                    progress(value, change, indexSet)
+                    progress((value is NSNull) ? nilValue : value, change, indexSet)
                 }
                 
                 configure.pause = { observer.stop() }
@@ -66,21 +67,21 @@ public extension NSObject
 public struct KVO
 {
     /// creates new KVO Signal (new value only)
-    public static func signal(object: NSObject, _ keyPath: String) -> Signal<AnyObject?>
+    public static func signal(object: NSObject, _ keyPath: String, _ nilValue: AnyObject? = nil) -> Signal<AnyObject?>
     {
-        return object.signal(keyPath: keyPath)
+        return object.signal(keyPath: keyPath, nilValue: nilValue)
     }
     
     /// creates new KVO Signal (initial + new value)
-    public static func startingSignal(object: NSObject, _ keyPath: String) -> Signal<AnyObject?>
+    public static func startingSignal(object: NSObject, _ keyPath: String, _ nilValue: AnyObject? = nil) -> Signal<AnyObject?>
     {
-        return object.startingSignal(keyPath: keyPath)
+        return object.startingSignal(keyPath: keyPath, nilValue: nilValue)
     }
 
     /// creates new KVO Signal (new value, keyValueChange, indexSet)
-    public static func detailedSignal(object: NSObject, _ keyPath: String) -> Signal<(AnyObject?, NSKeyValueChange, NSIndexSet?)>
+    public static func detailedSignal(object: NSObject, _ keyPath: String, _ nilValue: AnyObject? = nil) -> Signal<(AnyObject?, NSKeyValueChange, NSIndexSet?)>
     {
-        return object.detailedSignal(keyPath: keyPath)
+        return object.detailedSignal(keyPath: keyPath, nilValue: nilValue)
     }
 }
 

--- a/ReactKit/Foundation/KVO.swift
+++ b/ReactKit/Foundation/KVO.swift
@@ -31,8 +31,9 @@ public extension NSObject
     /// creates new KVO Signal (initial + new value)
     public func startingSignal(#keyPath: String, nilValue: AnyObject? = nil) -> Signal<AnyObject?>
     {
-        let initial: AnyObject? = self.valueForKeyPath(keyPath)
-        return self.signal(keyPath: keyPath, nilValue: nilValue).startWith((initial is NSNull) ? nilValue : initial)
+        var initial: AnyObject? = self.valueForKeyPath(keyPath)
+        initial = (initial is NSNull) ? nilValue : initial
+        return self.signal(keyPath: keyPath, nilValue: nilValue).startWith(initial)
     }
     
     ///


### PR DESCRIPTION
Because KVO emits NSNull values when the target value is nil we should allow the option to set a nil value placeholder.

This allows cleaner binding without having to monitor for NSNull and map it to nil or a default value.