### PR TITLE
Fix KVO returning NSNull by converting to nil.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ DerivedData
 *.xcuserstate
 
 Carthage/Build
+.DS_Store

--- a/ReactKitTests/KVOTests.swift
+++ b/ReactKitTests/KVOTests.swift
@@ -58,6 +58,42 @@ class KVOTests: _TestCase
         self.wait()
     }
     
+    func testKVO_nil()
+    {
+        let expect = self.expectationWithDescription(__FUNCTION__)
+        
+        let obj1 = MyObject()
+        let obj2 = MyObject()
+        
+        let signal = KVO.signal(obj1, "optionalValue")
+        
+        // REACT: obj1.optionalValue ~> obj2.optionalValue
+        (obj2, "optionalValue") <~ signal
+        
+        println("*** Start ***")
+        
+        XCTAssertNil(obj1.optionalValue)
+        XCTAssertNil(obj2.optionalValue)
+        
+        self.perform {
+            
+            obj1.optionalValue = "hoge"
+            
+            XCTAssertEqual(obj1.optionalValue!, "hoge")
+            XCTAssertEqual(obj2.optionalValue!, "hoge")
+            
+            obj1.optionalValue = nil
+            
+            XCTAssertNil(obj1.optionalValue)
+            XCTAssertNil(obj2.optionalValue)
+            
+            expect.fulfill()
+            
+        }
+        
+        self.wait()
+    }
+    
     /// e.g. (obj2, "value") <~ (obj1, "value")
     func testKVO_shortLivingSyntax()
     {

--- a/ReactKitTests/KVOTests.swift
+++ b/ReactKitTests/KVOTests.swift
@@ -66,14 +66,50 @@ class KVOTests: _TestCase
         let obj2 = MyObject()
         
         let signal = KVO.signal(obj1, "optionalValue")
-        
-        // REACT: obj1.optionalValue ~> obj2.optionalValue
-        (obj2, "optionalValue") <~ signal
+        (obj2, "optionalValue") <~ signal   // REACT
         
         println("*** Start ***")
         
         XCTAssertNil(obj1.optionalValue)
         XCTAssertNil(obj2.optionalValue)
+        
+        self.perform {
+            
+            obj1.optionalValue = "hoge"
+            
+            XCTAssertEqual(obj1.optionalValue!, "hoge")
+            XCTAssertEqual(obj2.optionalValue!, "hoge")
+            
+            obj1.optionalValue = nil
+            
+            XCTAssertNil(obj1.optionalValue)
+            XCTAssertNil(obj2.optionalValue, "nil should be set instead of NSNull.")
+            
+            expect.fulfill()
+            
+        }
+        
+        self.wait()
+    }
+
+    func testKVO_startingSignal()
+    {
+        let expect = self.expectationWithDescription(__FUNCTION__)
+        
+        let obj1 = MyObject()
+        let obj2 = MyObject()
+        obj2.optionalValue = "initial"  // set initial optionalValue
+
+        XCTAssertNil(obj1.optionalValue)
+        XCTAssertEqual(obj2.optionalValue!, "initial")
+        
+        let startingSignal = KVO.startingSignal(obj1, "optionalValue")
+        (obj2, "optionalValue") <~ startingSignal   // REACT
+
+        println("*** Start ***")
+        
+        XCTAssertNil(obj1.optionalValue)
+        XCTAssertNil(obj2.optionalValue, "`KVO.startingSignal()` sets initial `obj1.optionalValue` (nil) to `obj2.optionalValue` on `<~` binding.")
         
         self.perform {
             

--- a/ReactKitTests/_MyObject.swift
+++ b/ReactKitTests/_MyObject.swift
@@ -15,6 +15,8 @@ class MyObject: NSObject
     // http://vperi.com/2014/08/11/key-value-observation-in-swift-beta-5/
     dynamic var value: String = "initial"
     
+    dynamic var optionalValue: String? = nil
+    
     dynamic var number: NSNumber = 0
     
     dynamic var notification: NSNotification?


### PR DESCRIPTION
This pull request is an improvement from #18, 
applying `NSNull -> nil` conversion but reverting "nil value placeholder"
because KVO-signal initialization methods will become verbose and not quite useful
as discussed in https://github.com/ReactKit/ReactKit/pull/18#issuecomment-78226180.