### PR TITLE
Improve immediate-sequence stop-handling by adding configure.isFinished

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactKit/SwiftTask" ~> 2.6.3
+github "ReactKit/SwiftTask" ~> 2.6.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "duemunk/Async" "32cec7ee89d6f1a39b10f2f69d91640ba3416eca"
-github "ReactKit/SwiftTask" "2.6.3"
+github "ReactKit/SwiftTask" "2.6.4"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ XCTAssertEqual(obj1.value, "REACT")
 XCTAssertEqual(obj2.value, "REACT")
 ```
 
-To remove signal-bindings, just release `signal` itself.
+To remove signal-bindings, just release `signal` itself (or call `signal.cancel()`).
 
 ```swift
 self.obj1Signal = nil   // release signal & its bindings
@@ -83,10 +83,10 @@ let emailTextSignal = self.emailTextField.textChangedSignal()
 let passwordTextSignal = self.passwordTextField.textChangedSignal()
 let password2TextSignal = self.password2TextField.textChangedSignal()
 
-let anyTextSignal = Signal.any([usernameTextSignal, emailTextSignal, passwordTextSignal, password2TextSignal])
+let combinedTextSignal = Signal<NSString?>.merge2([usernameTextSignal, emailTextSignal, passwordTextSignal, password2TextSignal])
 
 // create button-enabling signal via any textField change
-self.buttonEnablingSignal = anyTextSignal.map { (values, changedValue) -> NSNumber? in
+self.buttonEnablingSignal = combinedTextSignal.map { (values, changedValue) -> NSNumber? in
 
     let username: NSString? = values[0]?
     let email: NSString? = values[1]?
@@ -109,11 +109,9 @@ For more examples, please see XCTestCases.
 
 ## How it works
 
-ReactKit is based on powerful [SwiftTask](https://github.com/ReactKit/SwiftTask) (JavaScript Promise-like) library, allowing to deliver multiple events (KVO, NSNotification, Target-Action, etc) continuously over time using its `progress` feature (`<~` operator in ReactKit).
+ReactKit is based on powerful [SwiftTask](https://github.com/ReactKit/SwiftTask) (JavaScript Promise-like) library, allowing to start & deliver multiple events (KVO, NSNotification, Target-Action, etc) continuously over time using its **resume & progress** feature (`<~` operator in ReactKit).
 
-Unlike many Reactive Extensions (Rx) libraries including [ReactiveCocoa](https://github.com/ReactiveCocoa/ReactiveCocoa) which has a basic concept of "hot" and "cold" signals, ReactKit gracefully integrated them into one **hot + paused (lazy) signal** `Signal<T>` class as well as **not adopting the concept of Disposable** but using `signal.cancel()` feature instead.
-
-Also in ReactKit, Rx's `signal.subscribe(onNext, onError, onComplete)` method is interpreted as `signal.progress()` (`<~`) and `signal.then()`/`success()`/`failure()` separately. When they are called on needs, they will start lazy evaluation.
+Unlike many Reactive Extensions (Rx) libraries including [ReactiveCocoa](https://github.com/ReactiveCocoa/ReactiveCocoa) which has a basic concept of "hot" and "cold" signals, ReactKit gracefully integrated them into one **hot + paused (lazy) signal** `Signal<T>` class. Also, Rx's `signal.subscribe(onNext, onError, onComplete)` method is interpreted as `signal.react()` (`<~`) and `signal.then()`/`success()`/`failure()` separately. Note that **lazy signals can be auto-resumed via `<~` operator**.
 
 
 ## Methods
@@ -121,40 +119,52 @@ Also in ReactKit, Rx's `signal.subscribe(onNext, onError, onComplete)` method is
 ### Signal Operations
 
 - Instance Methods
-  - `filter(f: T -> Bool)`
-  - `filter2(f: (old: T?, new: T) -> Bool)`
-  - `map(f: T -> U)`
-  - `flatMap(f: T -> Signal<U>)`
-  - `map2(f: (old: T?, new: T) -> U)`
-  - `mapAccumulate(initialValue, accumulator)` (alias: `scan`)
-  - `take(count)`
-  - `takeUntil(signal)`
-  - `skip(count)`
-  - `skipUntil(signal)`
-  - `merge(signal)`
-  - `concat(signal)`
-  - `startWith(initialValue)`
-  - `zip(signal)`
-  - `buffer(count)`
-  - `bufferBy(signal)`
-  - `delay(timeInterval)`
-  - `throttle(timeInterval)`
-  - `debounce(timeInterval)`
+  - Transforming
+    - `map(f: T -> U)`
+    - `flatMap(f: T -> Signal<U>)`
+    - `map2(f: (old: T?, new: T) -> U)`
+    - `mapAccumulate(initialValue, accumulator)` (alias: `scan`)
+    - `buffer(count)`
+    - `bufferBy(signal)`
+    - `groupBy(classifier: T -> Key)`
+    - `customize(...)`
+  - Filtering
+    - `filter(f: T -> Bool)`
+    - `filter2(f: (old: T?, new: T) -> Bool)`
+    - `take(count)`
+    - `takeUntil(signal)`
+    - `skip(count)`
+    - `skipUntil(signal)`
+    - `sample(signal)`
+  - Combining
+    - `merge(signal)`
+    - `concat(signal)`
+    - `startWith(initialValue)`
+    - `zip(signal)`
+  - Timing
+    - `delay(timeInterval)`
+    - `throttle(timeInterval)`
+    - `debounce(timeInterval)`
 - Class Methods
-  - `merge(signals)`
-  - `merge2(signals)` (generalized method for `merge` & `combineLatest`)
-  - `combineLatest(signals)`
-  - `concat(signals)`
-  - `zip(signals)`
+  - Combining
+    - `merge(signals)`
+    - `merge2(signals)` (generalized method for `merge` & `combineLatest`)
+    - `combineLatest(signals)`
+    - `concat(signals)`
+    - `zip(signals)`
 
 ### Helpers
 
-- `asSignal(ValueType)` (WARNING: currently works for non-Optional only)
-- `Signal.once(value)` (alias: `just`)
-- `Signal.never()`
-- `Signal.fulfilled()` (alias: `empty`)
-- `Signal.rejected()` (alias: `error`)
-- `Signal(values:)` (a.k.a Rx.fromArray)
+- Creating
+  - `asSignal(ValueType)` (WARNING: currently works for non-Optional only)
+  - `Signal.once(value)` (alias: `just`)
+  - `Signal.never()`
+  - `Signal.fulfilled()` (alias: `empty`)
+  - `Signal.rejected()` (alias: `error`)
+  - `Signal(values:)` (a.k.a Rx.fromArray)
+- Utility
+  - `peek(f: T -> Void)` (for injecting side effects e.g. debug-logging)
+  - `ownedBy(owner: NSObject)` (easy strong referencing to keep signals alive)
 
 
 ## Dependencies

--- a/ReactKit.xcodeproj/project.pbxproj
+++ b/ReactKit.xcodeproj/project.pbxproj
@@ -25,8 +25,8 @@
 		1F822EF419D319FF00A3CA23 /* _MyObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F822EF219D319FF00A3CA23 /* _MyObject.swift */; };
 		1F8C3AAB1A2D8614000D9CF8 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8C3AAA1A2D8614000D9CF8 /* Error.swift */; };
 		1F8C3AAC1A2D8614000D9CF8 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8C3AAA1A2D8614000D9CF8 /* Error.swift */; };
-		1FC50FF31AB9DA5400F363CD /* InfiniteSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC50FF21AB9DA5400F363CD /* InfiniteSequenceTests.swift */; };
-		1FC50FF41AB9DA5400F363CD /* InfiniteSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC50FF21AB9DA5400F363CD /* InfiniteSequenceTests.swift */; };
+		1FC50FF31AB9DA5400F363CD /* ImmediateSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC50FF21AB9DA5400F363CD /* ImmediateSequenceTests.swift */; };
+		1FC50FF41AB9DA5400F363CD /* ImmediateSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC50FF21AB9DA5400F363CD /* ImmediateSequenceTests.swift */; };
 		1FED88FE19C1EB120065658B /* ReactKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FED88FD19C1EB120065658B /* ReactKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1FED896119C1EBD60065658B /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FED895C19C1EBD60065658B /* Signal.swift */; };
 		1FED896219C1EBD60065658B /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FED895C19C1EBD60065658B /* Signal.swift */; };
@@ -63,7 +63,7 @@
 		1F822EE619D319E000A3CA23 /* CustomOperatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomOperatorTests.swift; sourceTree = "<group>"; };
 		1F822EF219D319FF00A3CA23 /* _MyObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _MyObject.swift; sourceTree = "<group>"; };
 		1F8C3AAA1A2D8614000D9CF8 /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
-		1FC50FF21AB9DA5400F363CD /* InfiniteSequenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfiniteSequenceTests.swift; sourceTree = "<group>"; };
+		1FC50FF21AB9DA5400F363CD /* ImmediateSequenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImmediateSequenceTests.swift; sourceTree = "<group>"; };
 		1FED88F819C1EB120065658B /* ReactKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FED88FC19C1EB120065658B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1FED88FD19C1EB120065658B /* ReactKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReactKit.h; sourceTree = "<group>"; };
@@ -192,7 +192,7 @@
 				1F14EC4319C1FC040090C3D8 /* NotificationTests.swift */,
 				1F822EE619D319E000A3CA23 /* CustomOperatorTests.swift */,
 				1F563DF119D701F100034EA6 /* DeinitSignalTests.swift */,
-				1FC50FF21AB9DA5400F363CD /* InfiniteSequenceTests.swift */,
+				1FC50FF21AB9DA5400F363CD /* ImmediateSequenceTests.swift */,
 				1FED890819C1EB120065658B /* Supporting Files */,
 			);
 			path = ReactKitTests;
@@ -424,7 +424,7 @@
 			files = (
 				1F2BEB601AAAB3A500256A58 /* ArrayKVOTests.swift in Sources */,
 				1F626D9019D8799600D3ABCE /* CustomOperatorTests.swift in Sources */,
-				1FC50FF31AB9DA5400F363CD /* InfiniteSequenceTests.swift in Sources */,
+				1FC50FF31AB9DA5400F363CD /* ImmediateSequenceTests.swift in Sources */,
 				1F822EF319D319FF00A3CA23 /* _MyObject.swift in Sources */,
 				1FED8AAA19C1ECD30065658B /* _TestCase.swift in Sources */,
 				484553991A4CF97C007770CA /* Async.swift in Sources */,
@@ -461,7 +461,7 @@
 			files = (
 				1F2BEB611AAAB3A500256A58 /* ArrayKVOTests.swift in Sources */,
 				1F626D9419D8799900D3ABCE /* CustomOperatorTests.swift in Sources */,
-				1FC50FF41AB9DA5400F363CD /* InfiniteSequenceTests.swift in Sources */,
+				1FC50FF41AB9DA5400F363CD /* ImmediateSequenceTests.swift in Sources */,
 				1F822EF419D319FF00A3CA23 /* _MyObject.swift in Sources */,
 				1FED8AAB19C1ECD30065658B /* _TestCase.swift in Sources */,
 				4845539A1A4CF97C007770CA /* Async.swift in Sources */,

--- a/ReactKit.xcodeproj/project.pbxproj
+++ b/ReactKit.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		1F822EF419D319FF00A3CA23 /* _MyObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F822EF219D319FF00A3CA23 /* _MyObject.swift */; };
 		1F8C3AAB1A2D8614000D9CF8 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8C3AAA1A2D8614000D9CF8 /* Error.swift */; };
 		1F8C3AAC1A2D8614000D9CF8 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8C3AAA1A2D8614000D9CF8 /* Error.swift */; };
+		1FC50FF31AB9DA5400F363CD /* InfiniteSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC50FF21AB9DA5400F363CD /* InfiniteSequenceTests.swift */; };
+		1FC50FF41AB9DA5400F363CD /* InfiniteSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC50FF21AB9DA5400F363CD /* InfiniteSequenceTests.swift */; };
 		1FED88FE19C1EB120065658B /* ReactKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FED88FD19C1EB120065658B /* ReactKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1FED896119C1EBD60065658B /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FED895C19C1EBD60065658B /* Signal.swift */; };
 		1FED896219C1EBD60065658B /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FED895C19C1EBD60065658B /* Signal.swift */; };
@@ -61,6 +63,7 @@
 		1F822EE619D319E000A3CA23 /* CustomOperatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomOperatorTests.swift; sourceTree = "<group>"; };
 		1F822EF219D319FF00A3CA23 /* _MyObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _MyObject.swift; sourceTree = "<group>"; };
 		1F8C3AAA1A2D8614000D9CF8 /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
+		1FC50FF21AB9DA5400F363CD /* InfiniteSequenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfiniteSequenceTests.swift; sourceTree = "<group>"; };
 		1FED88F819C1EB120065658B /* ReactKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FED88FC19C1EB120065658B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1FED88FD19C1EB120065658B /* ReactKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReactKit.h; sourceTree = "<group>"; };
@@ -189,6 +192,7 @@
 				1F14EC4319C1FC040090C3D8 /* NotificationTests.swift */,
 				1F822EE619D319E000A3CA23 /* CustomOperatorTests.swift */,
 				1F563DF119D701F100034EA6 /* DeinitSignalTests.swift */,
+				1FC50FF21AB9DA5400F363CD /* InfiniteSequenceTests.swift */,
 				1FED890819C1EB120065658B /* Supporting Files */,
 			);
 			path = ReactKitTests;
@@ -420,6 +424,7 @@
 			files = (
 				1F2BEB601AAAB3A500256A58 /* ArrayKVOTests.swift in Sources */,
 				1F626D9019D8799600D3ABCE /* CustomOperatorTests.swift in Sources */,
+				1FC50FF31AB9DA5400F363CD /* InfiniteSequenceTests.swift in Sources */,
 				1F822EF319D319FF00A3CA23 /* _MyObject.swift in Sources */,
 				1FED8AAA19C1ECD30065658B /* _TestCase.swift in Sources */,
 				484553991A4CF97C007770CA /* Async.swift in Sources */,
@@ -456,6 +461,7 @@
 			files = (
 				1F2BEB611AAAB3A500256A58 /* ArrayKVOTests.swift in Sources */,
 				1F626D9419D8799900D3ABCE /* CustomOperatorTests.swift in Sources */,
+				1FC50FF41AB9DA5400F363CD /* InfiniteSequenceTests.swift in Sources */,
 				1F822EF419D319FF00A3CA23 /* _MyObject.swift in Sources */,
 				1FED8AAB19C1ECD30065658B /* _TestCase.swift in Sources */,
 				4845539A1A4CF97C007770CA /* Async.swift in Sources */,

--- a/ReactKit/Foundation/KVO.swift
+++ b/ReactKit/Foundation/KVO.swift
@@ -198,7 +198,7 @@ public func <~ <T: AnyObject>(tuple: (object: NSObject, keyPath: String), signal
     weak var object = tuple.object
     let keyPath = tuple.keyPath
     
-    signal.progress { (_, value: T?) in
+    signal.react { value in
         if let object = object {
             object.setValue(value, forKeyPath:keyPath)  // NOTE: don't use `tuple` inside closure, or object will be captured
         }
@@ -209,7 +209,7 @@ public func <~ <T: AnyObject>(tuple: (object: NSObject, keyPath: String), signal
 /// e.g. [ (obj1, "value1"), (obj2, "value2") ] <~ signal (sending [value1, value2] array)
 public func <~ <T: AnyObject>(tuples: [(object: NSObject, keyPath: String)], signal: Signal<[T?]>)
 {
-    signal.progress { (_, values: [T?]) in
+    signal.react { (values: [T?]) in
         for i in 0..<tuples.count {
             if i >= values.count { break }
             

--- a/ReactKit/Signal.swift
+++ b/ReactKit/Signal.swift
@@ -59,62 +59,11 @@ public class Signal<T>: Task<T, Void, NSError>
     }
     
     /// progress-chaining with auto-resume
-    public override func progress(progressClosure: ProgressTuple -> Void) -> Task<T, Void, NSError>
+    public func react(reactClosure: T -> Void) -> Self
     {
-        let signal = super.progress(progressClosure)
+        let signal = super.progress { _, value in reactClosure(value) }
         self.resume()
-        return signal
-    }
-    
-    /// then(value)-chaining with auto-resume
-    public func then(thenClosure: (Void?, ErrorInfo?) -> Void) -> Task<T, Void, NSError>
-    {
-        return self.then { (value: Void?, errorInfo: ErrorInfo?) -> Task<T, Void, NSError> in
-            thenClosure(value, errorInfo)
-            return Task<T, Void, NSError>(value: ())
-        }
-    }
-    
-    /// then(task)-chaining with auto-resume
-    public func then<U>(thenClosure: (Void?, ErrorInfo?) -> Task<U, Void, NSError>) -> Task<U, Void, NSError>
-    {
-        let signal = super.then(thenClosure)
-        self.resume()
-        return signal
-    }
-    
-    /// success(value)-chaining with auto-resume
-    public func success(successClosure: Void -> Void) -> Task<T, Void, NSError>
-    {
-        return self.success { _ -> Task<T, Void, NSError> in
-            successClosure()
-            return Task<T, Void, NSError>(value: ())
-        }
-    }
-    
-    /// success(task)-chaining with auto-resume
-    public func success<U>(successClosure: Void -> Task<U, Void, NSError>) -> Task<U, Void, NSError>
-    {
-        let signal = super.success(successClosure)
-        self.resume()
-        return signal
-    }
-    
-    /// failure(value)-chaining with auto-resume
-    public override func failure(failureClosure: ErrorInfo -> Void) -> Task<T, Void, NSError>
-    {
-        return self.failure { (errorInfo: ErrorInfo) -> Task<T, Void, NSError> in
-            failureClosure(errorInfo)
-            return Task<T, Void, NSError>(value: ())
-        }
-    }
-    
-    /// failure(task)-chaining with auto-resume
-    public override func failure<U>(failureClosure: ErrorInfo -> Task<U, Void, NSError>) -> Task<U, Void, NSError>
-    {
-        let signal = super.failure(failureClosure)
-        self.resume()
-        return signal
+        return self
     }
     
     // required (Swift compiler fails...)
@@ -139,6 +88,23 @@ public class Signal<T>: Task<T, Void, NSError>
 /// helper method to bind downstream's `fulfill`/`reject`/`configure` handlers with upstream
 private func _bindToUpstreamSignal<T>(upstreamSignal: Signal<T>, fulfill: (Void -> Void)?, reject: (NSError -> Void)?, configure: TaskConfiguration)
 {
+    //
+    // NOTE:
+    // Bind downstreamSignal's `configure` to upstreamSignal
+    // BEFORE performing its `progress()`/`then()`/`success()`/`failure()`
+    // so that even when downstream **immediately finishes** on its 1st resume,
+    // upstream can know `configure.isFinished = true`
+    // while performing its `initClosure`.
+    //
+    // This is especially important for stopping immediate-infinite-sequence,
+    // e.g. `infiniteSignal.take(3)` will stop infinite-while-loop at end of 3rd iteration.
+    //
+
+    // NOTE: downstreamSignal should capture upstreamSignal
+    configure.pause = { upstreamSignal.pause(); return }
+    configure.resume = { upstreamSignal.resume(); return }
+    configure.cancel = { upstreamSignal.cancel(); return }
+    
     if fulfill != nil || reject != nil {
         
         let signalName = upstreamSignal.name
@@ -165,11 +131,6 @@ private func _bindToUpstreamSignal<T>(upstreamSignal: Signal<T>, fulfill: (Void 
             
         }
     }
-    
-    // NOTE: downstreamSignal should capture upstreamSignal
-    configure.pause = { upstreamSignal.pause(); return }
-    configure.resume = { upstreamSignal.resume(); return }
-    configure.cancel = { upstreamSignal.cancel(); return }
 }
 
 //--------------------------------------------------
@@ -226,6 +187,8 @@ public extension Signal
             var generator = values.generate()
             while let value: T = generator.next() {
                 progress(value)
+                
+                if configure.isFinished { break }
             }
             fulfill()
         })
@@ -245,8 +208,8 @@ public extension Signal
     ) -> Signal<U>
     {
         return Signal<U> { progress, fulfill, reject, configure in
-            customizeClosure(upstreamSignal: self, progress: progress, fulfill: fulfill, reject: reject)
             _bindToUpstreamSignal(self, nil, nil, configure)
+            customizeClosure(upstreamSignal: self, progress: progress, fulfill: fulfill, reject: reject)
         }
     }
     
@@ -259,13 +222,13 @@ public extension Signal
     {
         return Signal<U> { progress, fulfill, reject, configure in
             
-            self.progress { (_, progressValue: T) in
-                progress(transform(progressValue))
+            _bindToUpstreamSignal(self, nil, reject, configure)
+            
+            self.react { value in
+                progress(transform(value))
             }.success {
                 fulfill()
             }
-            
-            _bindToUpstreamSignal(self, nil, reject, configure)
             
         }.name("\(self.name)-map")
     }
@@ -275,21 +238,21 @@ public extension Signal
     {
         return Signal<U> { progress, fulfill, reject, configure in
             
+            _bindToUpstreamSignal(self, nil, reject, configure)
+            
             // NOTE: each of `transformToSignal()` needs to be retained outside
             var innerSignals: [Signal<U>] = []
             
-            self.progress { (_, progressValue: T) in
-                let innerSignal = transform(progressValue)
+            self.react { value in
+                let innerSignal = transform(value)
                 innerSignals += [innerSignal]
                 
-                innerSignal.progress { (_, progressValue: U) in
-                    progress(progressValue)
+                innerSignal.react { value in
+                    progress(value)
                 }
             }.success {
                 fulfill()
             }
-            
-            _bindToUpstreamSignal(self, nil, reject, configure)
 
         }.name("\(self.name)-flatMap")
         
@@ -313,16 +276,16 @@ public extension Signal
     {
         return Signal<U> { progress, fulfill, reject, configure in
             
+            _bindToUpstreamSignal(self, nil, reject, configure)
+            
             var accumulatedValue: U = initialValue
             
-            self.progress { p in
-                accumulatedValue = accumulateClosure(accumulatedValue: accumulatedValue, newValue: p.newProgress)
+            self.react { value in
+                accumulatedValue = accumulateClosure(accumulatedValue: accumulatedValue, newValue: value)
                 progress(accumulatedValue)
             }.success {
                 fulfill()
             }
-            
-            _bindToUpstreamSignal(self, nil, reject, configure)
             
         }.name("\(self.name)-mapAccumulate")
     }
@@ -333,10 +296,12 @@ public extension Signal
         
         return Signal<[T]> { progress, fulfill, reject, configure in
             
+            _bindToUpstreamSignal(self, nil, reject, configure)
+            
             var buffer: [T] = []
             
-            self.progress { (_, progressValue: T) in
-                buffer += [progressValue]
+            self.react { value in
+                buffer += [value]
                 if buffer.count >= bufferCount {
                     progress(buffer)
                     buffer = []
@@ -346,8 +311,6 @@ public extension Signal
                 fulfill()
             }
             
-            _bindToUpstreamSignal(self, nil, reject, configure)
-            
         }.name("\(self.name)-buffer")
     }
     
@@ -355,16 +318,18 @@ public extension Signal
     {
         return Signal<[T]> { [weak triggerSignal] progress, fulfill, reject, configure in
             
+            _bindToUpstreamSignal(self, nil, reject, configure)
+            
             var buffer: [T] = []
             
-            self.progress { (_, progressValue: T) in
-                buffer += [progressValue]
+            self.react { value in
+                buffer += [value]
             }.success { _ -> Void in
                 progress(buffer)
                 fulfill()
             }
             
-            triggerSignal?.progress { [weak self] _ in
+            triggerSignal?.react { [weak self] _ in
                 if let self_ = self {
                     progress(buffer)
                     buffer = []
@@ -376,8 +341,6 @@ public extension Signal
                 }
             }
             
-            _bindToUpstreamSignal(self, nil, reject, configure)
-            
         }.name("\(self.name)-bufferBy")
     }
     
@@ -385,10 +348,12 @@ public extension Signal
     {
         return Signal<(Key, Signal<T>)> { progress, fulfill, reject, configure in
             
+            _bindToUpstreamSignal(self, fulfill, reject, configure)
+            
             var buffer: [Key : (signal: Signal<T>, progressHandler: Signal<T>.ProgressHandler)] = [:]
             
-            self.progress { (_, progressValue: T) in
-                let key = groupingClosure(progressValue)
+            self.react { value in
+                let key = groupingClosure(value)
                 
                 if buffer[key] == nil {
                     var progressHandler: Signal<T>.ProgressHandler?
@@ -403,11 +368,9 @@ public extension Signal
                     progress((key, buffer[key]!.signal) as (Key, Signal<T>))
                 }
                 
-                buffer[key]!.progressHandler(progressValue) // push value to innerSignal
+                buffer[key]!.progressHandler(value) // push value to innerSignal
                 
             }
-            
-            _bindToUpstreamSignal(self, fulfill, reject, configure)
             
         }.name("\(self.name)-groupBy")
     }
@@ -421,13 +384,13 @@ public extension Signal
     {
         return Signal<T> { progress, fulfill, reject, configure in
             
-            self.progress { (_, progressValue: T) in
-                if filterClosure(progressValue) {
-                    progress(progressValue)
+            _bindToUpstreamSignal(self, fulfill, reject, configure)
+            
+            self.react { value in
+                if filterClosure(value) {
+                    progress(value)
                 }
             }
-            
-            _bindToUpstreamSignal(self, fulfill, reject, configure)
             
         }.name("\(self.name)-filter")
     }
@@ -448,22 +411,22 @@ public extension Signal
     {
         return Signal<T> { progress, fulfill, reject, configure in
             
+            _bindToUpstreamSignal(self, nil, reject, configure)
+            
             var count = 0
             
-            self.progress { (_, progressValue: T) in
+            self.react { value in
                 count++
                 
                 if count < maxCount {
-                    progress(progressValue)
+                    progress(value)
                 }
                 else if count == maxCount {
-                    progress(progressValue)
+                    progress(value)
                     fulfill()   // successfully reached maxCount
                 }
                 
             }
-            
-            _bindToUpstreamSignal(self, fulfill, reject, configure)
             
         }.name("\(self.name)-take(\(maxCount))")
     }
@@ -473,14 +436,16 @@ public extension Signal
         return Signal<T> { [weak triggerSignal] progress, fulfill, reject, configure in
             
             if let triggerSignal = triggerSignal {
-
-                self.progress { (_, progressValue: T) in
-                    progress(progressValue)
+                
+                _bindToUpstreamSignal(self, fulfill, reject, configure)
+                
+                self.react { value in
+                    progress(value)
                 }
 
                 let cancelError = _RKError(.CancelledByTriggerSignal, "Signal=\(self.name) is cancelled by takeUntil(\(triggerSignal.name)).")
                 
-                triggerSignal.progress { [weak self] _ in
+                triggerSignal.react { [weak self] _ in
                     if let self_ = self {
                         self_.cancel(error: cancelError)
                     }
@@ -489,8 +454,6 @@ public extension Signal
                         self_.cancel(error: cancelError)
                     }
                 }
-                
-                _bindToUpstreamSignal(self, fulfill, reject, configure)
             }
             else {
                 let cancelError = _RKError(.CancelledByTriggerSignal, "Signal=\(self.name) is cancelled by takeUntil() with `triggerSignal` already been deinited.")
@@ -504,16 +467,16 @@ public extension Signal
     {
         return Signal<T> { progress, fulfill, reject, configure in
             
+            _bindToUpstreamSignal(self, fulfill, reject, configure)
+            
             var count = 0
             
-            self.progress { (_, progressValue: T) in
+            self.react { value in
                 count++
                 if count <= skipCount { return }
                 
-                progress(progressValue)
+                progress(value)
             }
-            
-            _bindToUpstreamSignal(self, fulfill, reject, configure)
             
         }.name("\(self.name)-skip(\(skipCount))")
     }
@@ -522,16 +485,18 @@ public extension Signal
     {
         return Signal<T> { [weak triggerSignal] progress, fulfill, reject, configure in
             
+            _bindToUpstreamSignal(self, fulfill, reject, configure)
+            
             var shouldSkip = true
             
-            self.progress { (_, progressValue: T) in
+            self.react { value in
                 if !shouldSkip {
-                    progress(progressValue)
+                    progress(value)
                 }
             }
             
             if let triggerSignal = triggerSignal {
-                triggerSignal.progress { _ in
+                triggerSignal.react { _ in
                     shouldSkip = false
                 }.then { _ -> Void in
                     shouldSkip = false
@@ -541,8 +506,6 @@ public extension Signal
                 shouldSkip = false
             }
             
-            _bindToUpstreamSignal(self, fulfill, reject, configure)
-            
         }.name("\(self.name)-skipUntil")
     }
     
@@ -550,21 +513,21 @@ public extension Signal
     {
         return Signal<T> { [weak triggerSignal] progress, fulfill, reject, configure in
             
-            var lastProgressValue: T?
+            _bindToUpstreamSignal(self, fulfill, reject, configure)
             
-            self.progress { (_, progressValue: T) in
-                lastProgressValue = progressValue
+            var lastValue: T?
+            
+            self.react { value in
+                lastValue = value
             }
             
             if let triggerSignal = triggerSignal {
-                triggerSignal.progress { _ in
-                    if let lastProgressValue = lastProgressValue {
-                        progress(lastProgressValue)
+                triggerSignal.react { _ in
+                    if let lastValue = lastValue {
+                        progress(lastValue)
                     }
                 }
             }
-            
-            _bindToUpstreamSignal(self, fulfill, reject, configure)
             
         }
     }
@@ -622,23 +585,23 @@ public extension Signal
     {
         return Signal<T> { progress, fulfill, reject, configure in
             
-            self.progress { (_, progressValue: T) in
+            _bindToUpstreamSignal(self, nil, reject, configure)
+            
+            self.react { value in
                 var timerSignal: Signal<Void>? = NSTimer.signal(timeInterval: timeInterval, repeats: false) { _ in }
                 
-                timerSignal!.progress { _ -> Void in
-                    progress(progressValue)
+                timerSignal!.react { _ in
+                    progress(value)
                     timerSignal = nil
                 }
             }.success { _ -> Void in
                 var timerSignal: Signal<Void>? = NSTimer.signal(timeInterval: timeInterval, repeats: false) { _ in }
                 
-                timerSignal!.progress { _ -> Void in
+                timerSignal!.react { _ in
                     fulfill()
                     timerSignal = nil
                 }
             }
-            
-            _bindToUpstreamSignal(self, nil, reject, configure)
             
         }.name("\(self.name)-delay(\(timeInterval))")
     }
@@ -649,19 +612,19 @@ public extension Signal
     {
         return Signal<T> { progress, fulfill, reject, configure in
             
+            _bindToUpstreamSignal(self, fulfill, reject, configure)
+            
             var lastProgressDate = NSDate(timeIntervalSince1970: 0)
             
-            self.progress { (_, progressValue: T) in
+            self.react { value in
                 let now = NSDate()
                 let timeDiff = now.timeIntervalSinceDate(lastProgressDate)
                 
                 if timeDiff > timeInterval {
                     lastProgressDate = now
-                    progress(progressValue)
+                    progress(value)
                 }
             }
-            
-            _bindToUpstreamSignal(self, fulfill, reject, configure)
             
         }.name("\(self.name)-throttle(\(timeInterval))")
     }
@@ -672,18 +635,18 @@ public extension Signal
     {
         return Signal<T> { progress, fulfill, reject, configure in
             
-            var timerSignal: Signal<Void>? = nil    // retained by self via self.progress
+            _bindToUpstreamSignal(self, fulfill, reject, configure)
             
-            self.progress { (_, progressValue: T) in
+            var timerSignal: Signal<Void>? = nil    // retained by self via self.react()
+            
+            self.react { value in
                 // NOTE: overwrite to deinit & cancel old timerSignal
                 timerSignal = NSTimer.signal(timeInterval: timeInterval, repeats: false) { _ in }
                 
-                timerSignal!.progress { _ -> Void in
-                    progress(progressValue)
+                timerSignal!.react { _ in
+                    progress(value)
                 }
             }
-            
-            _bindToUpstreamSignal(self, fulfill, reject, configure)
             
         }.name("\(self.name)-debounce(\(timeInterval))")
     }
@@ -708,8 +671,8 @@ public extension Signal
         return Signal<T> { progress, fulfill, reject, configure in
             
             for signal in signals {
-                signal.progress { (_, progressValue: U) in
-                    progress(progressValue as T)
+                signal.react { value in
+                    progress(value as T)
                 }.then { value, errorInfo -> Void in
                     if value != nil {
                         fulfill()
@@ -759,9 +722,9 @@ public extension Signal
                 
                 let signal = signals[i]
                 
-                signal.progress { (_, progressValue: U) in
-                    states[i] = progressValue
-                    progress((states.map { $0 as? T }, progressValue as T))
+                signal.react { value in
+                    states[i] = value
+                    progress((states.map { $0 as? T }, value as T))
                 }.then { value, errorInfo -> Void in
                     if value != nil {
                         fulfill()
@@ -818,8 +781,8 @@ public extension Signal
                 
                 if let signal = signals.first {
                     
-                    signal.progress { _, progressValue in
-                        progress(progressValue as T)
+                    signal.react { value in
+                        progress(value as T)
                     }.success {
                         concatRecursively(Array(signals[1..<signals.count]))
                     }.failure { errorInfo -> Void in
@@ -868,9 +831,9 @@ public extension Signal
             
             for i in 0..<signalCount {
                 
-                signals[i].progress { (_, progressValue: U) in
+                signals[i].react { value in
                     
-                    storedValuesArray[i] += [progressValue as T]
+                    storedValuesArray[i] += [value as T]
                     
                     var canProgress: Bool = true
                     for storedValues in storedValuesArray {
@@ -953,20 +916,20 @@ public extension Signal
 // NOTE: set precedence=255 to avoid "Operator is not a known binary operator" error
 infix operator ~> { associativity left precedence 255 }
 
-/// i.e. signal.progress { ... }
+/// i.e. signal.react { ... }
 public func ~> <T>(signal: Signal<T>, reactClosure: T -> Void) -> Signal<T>
 {
-    signal.progress { _, progress in reactClosure(progress) }
+    signal.react { value in reactClosure(value) }
     return signal
 }
 
 infix operator <~ { associativity right }
 
-/// closure-first operator, reversing `signal.progress { ... }`
+/// closure-first operator, reversing `signal.react { ... }`
 /// e.g. ^{ ... } <~ signal
 public func <~ <T>(reactClosure: T -> Void, signal: Signal<T>)
 {
-    signal.progress { _, progress in reactClosure(progress) }
+    signal.react { value in reactClosure(value) }
 }
 
 prefix operator ^ {}

--- a/ReactKitTests/ImmediateSequenceTests.swift
+++ b/ReactKitTests/ImmediateSequenceTests.swift
@@ -1,5 +1,5 @@
 //
-//  InfiniteSequenceTests.swift
+//  ImmediateSequenceTests.swift
 //  ReactKitTests
 //
 //  Created by Yasuhiro Inami on 2014/09/11.
@@ -9,7 +9,7 @@
 import ReactKit
 import XCTest
 
-class InfiniteSequenceTests: _TestCase
+class ImmediateSequenceTests: _TestCase
 {
     func testTake()
     {
@@ -48,7 +48,7 @@ class InfiniteSequenceTests: _TestCase
     }
 }
 
-class AsyncInfiniteSequenceTests: InfiniteSequenceTests
+class AsyncImmediateSequenceTests: ImmediateSequenceTests
 {
     override var isAsync: Bool { return true }
 }

--- a/ReactKitTests/InfiniteSequenceTests.swift
+++ b/ReactKitTests/InfiniteSequenceTests.swift
@@ -1,0 +1,54 @@
+//
+//  InfiniteSequenceTests.swift
+//  ReactKitTests
+//
+//  Created by Yasuhiro Inami on 2014/09/11.
+//  Copyright (c) 2014年 Yasuhiro Inami. All rights reserved.
+//
+
+import ReactKit
+import XCTest
+
+class InfiniteSequenceTests: _TestCase
+{
+    func testTake()
+    {
+        let expect = self.expectationWithDescription(__FUNCTION__)
+        
+        let sourceSignal = Signal(values: [Int](1...5))
+        let takeSignal = sourceSignal.take(3)
+        
+        var sourceBuffer = [Int]()
+        var takeBuffer = [Int]()
+        
+        // NOTE: peek = progress without auto-resume
+        sourceSignal.peek { value in
+            println("sourceSignal new value = \(value)")
+            sourceBuffer += [value]
+        }
+        
+        // REACT
+        takeSignal ~> { value in
+            println("[REACT] takeSignal new value = \(value)")
+            takeBuffer += [value]
+        }
+        
+        println("*** Start ***")
+        
+        self.perform {
+            
+            XCTAssertEqual(takeBuffer, [1, 2, 3])
+            XCTAssertEqual(sourceBuffer, [1, 2, 3], "`sourceBuffer` should return 3 elements and not iterating all immediate-sequence values.")
+            
+            expect.fulfill()
+            
+        }
+        
+        self.wait()
+    }
+}
+
+class AsyncInfiniteSequenceTests: InfiniteSequenceTests
+{
+    override var isAsync: Bool { return true }
+}

--- a/ReactKitTests/KVOTests.swift
+++ b/ReactKitTests/KVOTests.swift
@@ -693,6 +693,8 @@ class KVOTests: _TestCase
         
         }
         
+        takeSignal.resume() // NOTE: resume manually
+        
         self.perform { [weak sourceSignal] in
             sourceSignal?.cancel()
             return


### PR DESCRIPTION
This pull request is a performance improvement for stopping immediate-sequence (or Rx.Enumerable) iteration.

For example, 

```
let sourceSignal = Signal(values: [Int](1...Int.max))
let takeSignal = sourceSignal.take(3)

takeSignal.resume()  // start lazy evaluation without any handlers
```

#### As-Is

- `takeSignal` will send (iterate) `3` times immediately (good)
- `sourceSignal` will send `Int.max` times immediately (bad)

#### To-Be

- `sourceSignal` should iterate only `3` times.


See [ImmediateSequenceTests.swift](https://github.com/ReactKit/ReactKit/blob/89389818c08eef02a541c8fc90342f62a16ba903/ReactKitTests/ImmediateSequenceTests.swift#L40-L41) for more information. 