### PR TITLE
Add DynamicArray feature.

### DIFF
--- a/ReactKit.xcodeproj/project.pbxproj
+++ b/ReactKit.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		1F626D9319D8799900D3ABCE /* NotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F14EC4319C1FC040090C3D8 /* NotificationTests.swift */; };
 		1F626D9419D8799900D3ABCE /* CustomOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F822EE619D319E000A3CA23 /* CustomOperatorTests.swift */; };
 		1F626D9519D8799900D3ABCE /* DeinitSignalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F563DF119D701F100034EA6 /* DeinitSignalTests.swift */; };
+		1F72332B1ABDB34C00A0C8CF /* NSMutableIndexSet+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F72332A1ABDB34C00A0C8CF /* NSMutableIndexSet+Helper.swift */; };
+		1F72332C1ABDB34C00A0C8CF /* NSMutableIndexSet+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F72332A1ABDB34C00A0C8CF /* NSMutableIndexSet+Helper.swift */; };
 		1F79711019E4150A0067A4C4 /* NSTimer+Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F79710F19E4150A0067A4C4 /* NSTimer+Signal.swift */; };
 		1F79711119E4150A0067A4C4 /* NSTimer+Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F79710F19E4150A0067A4C4 /* NSTimer+Signal.swift */; };
 		1F822EF319D319FF00A3CA23 /* _MyObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F822EF219D319FF00A3CA23 /* _MyObject.swift */; };
@@ -32,6 +34,8 @@
 		1FED896219C1EBD60065658B /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FED895C19C1EBD60065658B /* Signal.swift */; };
 		1FED8AAA19C1ECD30065658B /* _TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FED8AA919C1ECD30065658B /* _TestCase.swift */; };
 		1FED8AAB19C1ECD30065658B /* _TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FED8AA919C1ECD30065658B /* _TestCase.swift */; };
+		480E83EB1ABB9B7400AF8346 /* DynamicArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480E83EA1ABB9B7400AF8346 /* DynamicArray.swift */; };
+		480E83EC1ABB9B7400AF8346 /* DynamicArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480E83EA1ABB9B7400AF8346 /* DynamicArray.swift */; };
 		484553991A4CF97C007770CA /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 484552D11A4CF97B007770CA /* Async.swift */; };
 		4845539A1A4CF97C007770CA /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 484552D11A4CF97B007770CA /* Async.swift */; };
 		484554ED1A4CF9CD007770CA /* SwiftTask.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 484554EC1A4CF9CD007770CA /* SwiftTask.framework */; };
@@ -59,6 +63,7 @@
 		1F14EC4319C1FC040090C3D8 /* NotificationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationTests.swift; sourceTree = "<group>"; };
 		1F2BEB5F1AAAB3A500256A58 /* ArrayKVOTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayKVOTests.swift; sourceTree = "<group>"; };
 		1F563DF119D701F100034EA6 /* DeinitSignalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeinitSignalTests.swift; sourceTree = "<group>"; };
+		1F72332A1ABDB34C00A0C8CF /* NSMutableIndexSet+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSMutableIndexSet+Helper.swift"; sourceTree = "<group>"; };
 		1F79710F19E4150A0067A4C4 /* NSTimer+Signal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSTimer+Signal.swift"; sourceTree = "<group>"; };
 		1F822EE619D319E000A3CA23 /* CustomOperatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomOperatorTests.swift; sourceTree = "<group>"; };
 		1F822EF219D319FF00A3CA23 /* _MyObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _MyObject.swift; sourceTree = "<group>"; };
@@ -74,6 +79,7 @@
 		1FED894B19C1EB7D0065658B /* ReactKit-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ReactKit-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FED895C19C1EBD60065658B /* Signal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Signal.swift; sourceTree = "<group>"; };
 		1FED8AA919C1ECD30065658B /* _TestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _TestCase.swift; sourceTree = "<group>"; };
+		480E83EA1ABB9B7400AF8346 /* DynamicArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicArray.swift; sourceTree = "<group>"; };
 		484552D11A4CF97B007770CA /* Async.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Async.swift; sourceTree = "<group>"; };
 		484554EC1A4CF9CD007770CA /* SwiftTask.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftTask.framework; path = ../Carthage/Checkouts/SwiftTask/build/Debug/SwiftTask.framework; sourceTree = "<group>"; };
 		4875885119E4D94800828AD0 /* KVO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KVO.swift; sourceTree = "<group>"; };
@@ -125,10 +131,20 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1F7233291ABDB33F00A0C8CF /* Helper */ = {
+			isa = PBXGroup;
+			children = (
+				1F72332A1ABDB34C00A0C8CF /* NSMutableIndexSet+Helper.swift */,
+			);
+			path = Helper;
+			sourceTree = "<group>";
+		};
 		1F79710E19E414F70067A4C4 /* Foundation */ = {
 			isa = PBXGroup;
 			children = (
+				1F7233291ABDB33F00A0C8CF /* Helper */,
 				4875885119E4D94800828AD0 /* KVO.swift */,
+				480E83EA1ABB9B7400AF8346 /* DynamicArray.swift */,
 				4875885219E4D94800828AD0 /* Notification.swift */,
 				4875885419E4D94800828AD0 /* TargetAction.swift */,
 				4875885319E4D94800828AD0 /* NSObject+Deinit.swift */,
@@ -415,6 +431,8 @@
 				48DDE7721A0C41A300125F36 /* NSObject+Own.swift in Sources */,
 				4875885519E4D94800828AD0 /* KVO.swift in Sources */,
 				4890AA901A5B70650028586C /* Signal+Conversion.swift in Sources */,
+				480E83EB1ABB9B7400AF8346 /* DynamicArray.swift in Sources */,
+				1F72332B1ABDB34C00A0C8CF /* NSMutableIndexSet+Helper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -438,6 +456,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F72332C1ABDB34C00A0C8CF /* NSMutableIndexSet+Helper.swift in Sources */,
 				4875885A19E4D94800828AD0 /* NSObject+Deinit.swift in Sources */,
 				4875886319E4D95A00828AD0 /* UIControl+Signal.swift in Sources */,
 				1FED896219C1EBD60065658B /* Signal.swift in Sources */,
@@ -447,6 +466,7 @@
 				4875885619E4D94800828AD0 /* KVO.swift in Sources */,
 				48DDE7731A0C41A300125F36 /* NSObject+Own.swift in Sources */,
 				48FD5B3C19E51E7100913946 /* UIBarButtonItem+Signal.swift in Sources */,
+				480E83EC1ABB9B7400AF8346 /* DynamicArray.swift in Sources */,
 				4875886219E4D95A00828AD0 /* UIButton+Signal.swift in Sources */,
 				4875886419E4D95A00828AD0 /* UIGestureRecognizer+Signal.swift in Sources */,
 				4875885819E4D94800828AD0 /* Notification.swift in Sources */,

--- a/ReactKit/Foundation/DynamicArray.swift
+++ b/ReactKit/Foundation/DynamicArray.swift
@@ -1,0 +1,88 @@
+//
+//  DynamicArray.swift
+//  ReactKit
+//
+//  Created by Yasuhiro Inami on 2015/03/21.
+//  Copyright (c) 2015年 Yasuhiro Inami. All rights reserved.
+//
+
+import Foundation
+
+///
+/// Array-wrapper class to create mutableArrayValueForKey-`proxy` and its `signal`.
+///
+/// (NOTE: to forward changes to original array, use `ForwardingDynamicArray` instead)
+///
+public class DynamicArray: NSObject
+{
+    // NOTE: can't use generics for `DynamicArray` when collaborating with `mutableArrayValueForKey()`
+    public typealias Element = AnyObject
+    
+    public typealias ChangedTuple = ([Element]?, NSKeyValueChange, NSIndexSet)
+    
+    // (NOTE: must use non-private for KVC(mutableArrayValueForKey)-compliancy)
+    /// original array
+    internal private(set) var _array: [Element]
+    
+    private let _key = "_array"
+    
+    ///
+    /// Proxy array to send changes to `self.signal`.
+    ///
+    /// NOTE: Make sure to bind `self.signal` first i.e. `self.signal ~> { ... }` (KVO-addObserver) before using this.
+    ///
+    public var proxy: NSMutableArray
+    {
+        return self.mutableArrayValueForKey(self._key)
+    }
+    
+    /// sends `(changedValues, changedType, indexSet)` via `self.proxy`
+    public private(set) var signal: Signal<ChangedTuple>!
+    
+    public init(_ array: [Element] = [])
+    {
+        // NOTE: `self._array` will be change via `self.proxy`, but immutable `array` won't
+        self._array = array
+        
+        super.init()
+        
+        // NOTE: using `KVO.detailedSignal()` allows to also deliver NSKeyValueChange and NSIndexSet
+        // NOTE: `KVO.detailedSignal(self, self.key)` returns `value = nil` when `change = .Removal`
+        self.signal = KVO.detailedSignal(self, self._key).map { ($0 as? [Element], $1, $2!) }
+    }
+}
+
+///
+/// Forwards changes in ForwardingDynamicArray to original NSMutableArray
+/// (useful when original NSMutableArray is also using `mutableArrayValueForKey`)
+///
+/// e.g.
+///
+/// ```
+/// let dynamicArray = ForwardingDynamicArray(myObj.mutableArrayValueForKey("array"))
+/// dynamicArray.proxy.addObject(newItem)
+/// ```
+///
+/// will also add `newItem` to `myObj.array`, even when this array is NSArray (thanks to KVC magic).
+///
+public class ForwardingDynamicArray: DynamicArray
+{
+    public init(original originalMutableArray: NSMutableArray)
+    {
+        super.init(originalMutableArray)
+        
+        // REACT: forward changes to `originalMutableArray`
+        self.signal ~> { values, change, indexSet in
+            switch change {
+                case .Insertion:
+                    originalMutableArray.insertObjects(values!, atIndexes: indexSet)
+                case .Replacement:
+                    originalMutableArray.replaceObjectsAtIndexes(indexSet, withObjects: values!)
+                case .Removal:
+                    originalMutableArray.removeObjectsAtIndexes(indexSet)
+                default:
+                    break
+            }
+        }
+    }
+}

--- a/ReactKit/Foundation/Helper/NSMutableIndexSet+Helper.swift
+++ b/ReactKit/Foundation/Helper/NSMutableIndexSet+Helper.swift
@@ -1,0 +1,22 @@
+//
+//  NSMutableIndexSet+Helper.swift
+//  ReactKit
+//
+//  Created by Yasuhiro Inami on 2015/03/21.
+//  Copyright (c) 2015年 Yasuhiro Inami. All rights reserved.
+//
+
+import Foundation
+
+// helper
+extension NSMutableIndexSet
+{
+    public convenience init(indexes: [Int])
+    {
+        self.init()
+        
+        for index in indexes {
+            self.addIndex(index)
+        }
+    }
+}

--- a/ReactKitTests/ArrayKVOTests.swift
+++ b/ReactKitTests/ArrayKVOTests.swift
@@ -125,6 +125,7 @@ class ArrayKVOTests: _TestCase
             
             // addObject
             obj1ArrayProxy.addObject(1)
+            XCTAssertTrue(obj1.array.isEqualToArray([1]))
             XCTAssertEqual(lastValue!, [1])
             XCTAssertTrue(lastChange! == .Insertion)
             XCTAssertTrue(lastIndexSet!.isEqualToIndexSet(NSIndexSet(index: 0)))
@@ -133,6 +134,7 @@ class ArrayKVOTests: _TestCase
             
             // addObject (once more)
             obj1ArrayProxy.addObject(2)
+            XCTAssertTrue(obj1.array.isEqualToArray([1, 2]))
             XCTAssertEqual(lastValue!, [2])
             XCTAssertTrue(lastChange! == .Insertion)
             XCTAssertTrue(lastIndexSet!.isEqualToIndexSet(NSIndexSet(index: 1)))
@@ -140,98 +142,77 @@ class ArrayKVOTests: _TestCase
             
             // addObjectsFromArray
             obj1ArrayProxy.addObjectsFromArray([3, 4])
+            XCTAssertTrue(obj1.array.isEqualToArray([1, 2, 3, 4]))
             XCTAssertEqual(lastValue!, [4], "Only last added value `4` should be set.")
             XCTAssertTrue(lastChange! == .Insertion)
             XCTAssertTrue(lastIndexSet!.isEqualToIndexSet(NSIndexSet(index: 3)))
             XCTAssertEqual(reactedCount, 4, "`mutableArrayValueForKey().addObjectsFromArray()` will send `3` then `4` **separately** to signal, so `reactedCount` should be incremented as +2.")
             
-            // check array
-            XCTAssertTrue(obj1.array.isEqualToArray([1, 2, 3, 4]))
-            
             // insertObject
             obj1ArrayProxy.insertObject(0, atIndex: 0)
+            XCTAssertTrue(obj1.array.isEqualToArray([0, 1, 2, 3, 4]))
             XCTAssertEqual(lastValue!, [0])
             XCTAssertTrue(lastChange! == .Insertion)
             XCTAssertTrue(lastIndexSet!.isEqualToIndexSet(NSIndexSet(index: 0)))
             XCTAssertEqual(reactedCount, 5)
             
-            // prepare indexSet = [1, 3]
-            indexSet = NSMutableIndexSet(index: 1)
-            indexSet.addIndex(3)
-            
             // insertObjects
-            obj1ArrayProxy.insertObjects([0.5, 1.5], atIndexes: indexSet)
+            obj1ArrayProxy.insertObjects([0.5, 1.5], atIndexes: NSMutableIndexSet(indexes: [1, 3]))
+            XCTAssertTrue(obj1.array.isEqualToArray([0, 0.5, 1, 1.5, 2, 3, 4]))
             XCTAssertEqual(lastValue!, [0.5, 1.5])
             XCTAssertTrue(lastChange! == .Insertion)
-            XCTAssertTrue(lastIndexSet!.isEqualToIndexSet(indexSet))
+            XCTAssertTrue(lastIndexSet!.isEqualToIndexSet(NSMutableIndexSet(indexes: [1, 3])))
             XCTAssertEqual(reactedCount, 6, "`mutableArrayValueForKey().insertObjects()` will send `0.5` & `1.5` **together** to signal, so `reactedCount` should be incremented as +1.")
-            
-            // check array
-            XCTAssertTrue(obj1.array.isEqualToArray([0, 0.5, 1, 1.5, 2, 3, 4]))
             
             // replaceObjectAtIndex
             obj1ArrayProxy.replaceObjectAtIndex(4, withObject: 2.5)
+            XCTAssertTrue(obj1.array.isEqualToArray([0, 0.5, 1, 1.5, 2.5, 3, 4]))
             XCTAssertEqual(lastValue!, [2.5])
             XCTAssertTrue(lastChange! == .Replacement)
             XCTAssertTrue(lastIndexSet!.isEqualToIndexSet(NSIndexSet(index: 4)))
             XCTAssertEqual(reactedCount, 7)
             
-            // prepare indexSet = [5, 6]
-            indexSet = NSMutableIndexSet(index: 5)
-            indexSet.addIndex(6)
-            
             // replaceObjectsAtIndexes
-            obj1ArrayProxy.replaceObjectsAtIndexes(indexSet, withObjects: [3.5, 4.5])
+            obj1ArrayProxy.replaceObjectsAtIndexes(NSMutableIndexSet(indexes: [5, 6]), withObjects: [3.5, 4.5])
+            XCTAssertTrue(obj1.array.isEqualToArray([0, 0.5, 1, 1.5, 2.5, 3.5, 4.5]))
             XCTAssertEqual(lastValue!, [3.5, 4.5])
             XCTAssertTrue(lastChange! == .Replacement)
-            XCTAssertTrue(lastIndexSet!.isEqualToIndexSet(indexSet))
+            XCTAssertTrue(lastIndexSet!.isEqualToIndexSet(NSMutableIndexSet(indexes: [5,6])))
             XCTAssertEqual(reactedCount, 8)
-            
-            // check array
-            XCTAssertTrue(obj1.array.isEqualToArray([0, 0.5, 1, 1.5, 2.5, 3.5, 4.5]))
             
             // removeObjectAtIndex
             obj1ArrayProxy.removeObjectAtIndex(6)
+            XCTAssertTrue(obj1.array.isEqualToArray([0, 0.5, 1, 1.5, 2.5, 3.5]))
             XCTAssertNil(lastValue, "lastValue should be nil (deleting element `4.5`).")
             XCTAssertTrue(lastChange! == .Removal)
             XCTAssertTrue(lastIndexSet!.isEqualToIndexSet(NSIndexSet(index: 6)))
             XCTAssertEqual(reactedCount, 9)
             
-            // prepare indexSet = [0, 2]
-            indexSet = NSMutableIndexSet(index: 0)
-            indexSet.addIndex(2)
-            
             // removeObjectsAtIndexes
-            obj1ArrayProxy.removeObjectsAtIndexes(indexSet)
+            obj1ArrayProxy.removeObjectsAtIndexes(NSMutableIndexSet(indexes: [0, 2]))
+            XCTAssertTrue(obj1.array.isEqualToArray([0.5, 1.5, 2.5, 3.5]))
             XCTAssertNil(lastValue, "lastValue should be nil (deleting element `0` & `1`).")
             XCTAssertTrue(lastChange! == .Removal)
-            XCTAssertTrue(lastIndexSet!.isEqualToIndexSet(indexSet))
+            XCTAssertTrue(lastIndexSet!.isEqualToIndexSet(NSMutableIndexSet(indexes: [0, 2])))
             XCTAssertEqual(reactedCount, 10)
-            
-            // check array
-            XCTAssertTrue(obj1.array.isEqualToArray([0.5, 1.5, 2.5, 3.5]))
             
             // exchangeObjectAtIndex
             obj1ArrayProxy.exchangeObjectAtIndex(1, withObjectAtIndex: 2)   // replaces `index = 1` then `index = 2`
+            XCTAssertTrue(obj1.array.isEqualToArray([0.5, 2.5, 1.5, 3.5]))
             XCTAssertEqual(lastValue!, [1.5], "Only last replaced value `1.5` should be set.")
             XCTAssertTrue(lastChange! == .Replacement)
             XCTAssertTrue(lastIndexSet!.isEqualToIndexSet(NSIndexSet(index: 2)))
             XCTAssertEqual(reactedCount, 12, "`mutableArrayValueForKey().exchangeObjectAtIndex()` will send `2.5` (replacing at index=1) then `1.5` (replacing at index=2) **separately** to signal, so `reactedCount` should be incremented as +2.")
             
-            // check array
-            XCTAssertTrue(obj1.array.isEqualToArray([0.5, 2.5, 1.5, 3.5]))
-            
             // sortUsingComparator
             obj1ArrayProxy.sortUsingComparator { (element1, element2) -> NSComparisonResult in
                 return (element2 as NSNumber).compare(element1 as NSNumber)
             }
+            XCTAssertTrue(obj1.array.isEqualToArray([3.5, 2.5, 1.5, 0.5]))
             XCTAssertEqual(lastValue!, [0.5], "Only last replaced value `0.5` should be set.")
             XCTAssertTrue(lastChange! == .Replacement)
             XCTAssertTrue(lastIndexSet!.isEqualToIndexSet(NSIndexSet(index: 3)))
             XCTAssertEqual(reactedCount, 16, "`mutableArrayValueForKey().sortUsingComparator()` will send all sorted values **separately** to signal, so `reactedCount` should be incremented as number of elements i.e. +4.")
-            
-            // check array
-            XCTAssertTrue(obj1.array.isEqualToArray([3.5, 2.5, 1.5, 0.5]))
             
             expect.fulfill()
             
@@ -240,6 +221,152 @@ class ArrayKVOTests: _TestCase
         self.wait()
     }
     
+    func testDynamicArray()
+    {
+        let expect = self.expectationWithDescription(__FUNCTION__)
+        
+        let array = [Int]()
+        let dynamicArray = DynamicArray(array)
+        
+        var buffer: [DynamicArray.ChangedTuple] = []
+        
+        // REACT
+        dynamicArray.signal ~> { (context: DynamicArray.ChangedTuple) in
+            buffer.append(context)
+        }
+        
+        println("*** Start ***")
+        
+        XCTAssertEqual(dynamicArray.proxy.count, 0)
+        
+        self.perform {
+            
+            dynamicArray.proxy.addObject(1)
+            
+            XCTAssertEqual(dynamicArray.proxy, [1])
+            XCTAssertEqual(array, [], "`array` will not be synced with `dynamicArray` (use ForwardingDynamicArray instead).")
+            XCTAssertEqual(buffer.count, 1)
+            XCTAssertEqual(buffer[0].0! as [NSObject], [1])
+            XCTAssertEqual(buffer[0].1 as NSKeyValueChange, NSKeyValueChange.Insertion)
+            XCTAssertTrue((buffer[0].2 as NSIndexSet).isEqualToIndexSet(NSIndexSet(index: 0)))
+            
+            dynamicArray.proxy.addObjectsFromArray([2, 3])
+            
+            XCTAssertEqual(dynamicArray.proxy, [1, 2, 3])
+            XCTAssertEqual(buffer.count, 3, "`[2, 3]` will be separately inserted, so `buffer.count` should increment by 2.")
+            XCTAssertEqual(buffer[1].0! as [NSObject], [2])
+            XCTAssertEqual(buffer[1].1 as NSKeyValueChange, NSKeyValueChange.Insertion)
+            XCTAssertTrue((buffer[1].2 as NSIndexSet).isEqualToIndexSet(NSIndexSet(index: 1)))
+            XCTAssertEqual(buffer[2].0! as [NSObject], [3])
+            XCTAssertEqual(buffer[2].1 as NSKeyValueChange, NSKeyValueChange.Insertion)
+            XCTAssertTrue((buffer[2].2 as NSIndexSet).isEqualToIndexSet(NSIndexSet(index: 2)))
+            
+            dynamicArray.proxy.insertObject(0, atIndex: 0)
+            
+            XCTAssertEqual(dynamicArray.proxy, [0, 1, 2, 3])
+            XCTAssertEqual(buffer.count, 4)
+            XCTAssertEqual(buffer[3].0! as [NSObject], [0])
+            XCTAssertEqual(buffer[3].1 as NSKeyValueChange, NSKeyValueChange.Insertion)
+            XCTAssertTrue((buffer[3].2 as NSIndexSet).isEqualToIndexSet(NSIndexSet(index: 0)))
+            
+            dynamicArray.proxy.replaceObjectAtIndex(2, withObject: 2.5)
+            
+            XCTAssertEqual(dynamicArray.proxy, [0, 1, 2.5, 3])
+            XCTAssertEqual(buffer.count, 5)
+            XCTAssertEqual(buffer[4].0! as [NSObject], [2.5])
+            XCTAssertEqual(buffer[4].1 as NSKeyValueChange, NSKeyValueChange.Replacement)
+            XCTAssertTrue((buffer[4].2 as NSIndexSet).isEqualToIndexSet(NSIndexSet(index: 2)))
+            
+            dynamicArray.proxy.removeObjectAtIndex(2)
+            
+            XCTAssertEqual(dynamicArray.proxy, [0, 1, 3])
+            XCTAssertEqual(buffer.count, 6)
+            XCTAssertNil(buffer[5].0, "Deletion will send nil as changed value.")
+            XCTAssertEqual(buffer[5].1 as NSKeyValueChange, NSKeyValueChange.Removal)
+            XCTAssertTrue((buffer[5].2 as NSIndexSet).isEqualToIndexSet(NSIndexSet(index: 2)))
+            
+            expect.fulfill()
+            
+        }
+        
+        self.wait()
+    }
+    
+    func testForwardingDynamicArray()
+    {
+        let expect = self.expectationWithDescription(__FUNCTION__)
+        
+        let obj1 = MyObject()
+        
+        let dynamicArray = ForwardingDynamicArray(original: obj1.mutableArrayValueForKey("array"))
+        
+        var buffer: [DynamicArray.ChangedTuple] = []
+        
+        // REACT
+        dynamicArray.signal ~> { (context: DynamicArray.ChangedTuple) in
+            buffer.append(context)
+        }
+        
+        println("*** Start ***")
+        
+        XCTAssertEqual(dynamicArray.proxy.count, 0)
+        
+        self.perform {
+            
+            dynamicArray.proxy.addObject(1)
+            
+            XCTAssertEqual(dynamicArray.proxy, [1])
+            XCTAssertEqual(obj1.array, dynamicArray.proxy, "`obj1.array` will sync with `dynamicArray.proxy`.")
+            XCTAssertEqual(buffer.count, 1)
+            XCTAssertEqual(buffer[0].0! as [NSObject], [1])
+            XCTAssertEqual(buffer[0].1 as NSKeyValueChange, NSKeyValueChange.Insertion)
+            XCTAssertTrue((buffer[0].2 as NSIndexSet).isEqualToIndexSet(NSIndexSet(index: 0)))
+            
+            dynamicArray.proxy.addObjectsFromArray([2, 3])
+            
+            XCTAssertEqual(dynamicArray.proxy, [1, 2, 3])
+            XCTAssertEqual(obj1.array, dynamicArray.proxy)
+            XCTAssertEqual(buffer.count, 3, "`[2, 3]` will be separately inserted, so `buffer.count` should increment by 2.")
+            XCTAssertEqual(buffer[1].0! as [NSObject], [2])
+            XCTAssertEqual(buffer[1].1 as NSKeyValueChange, NSKeyValueChange.Insertion)
+            XCTAssertTrue((buffer[1].2 as NSIndexSet).isEqualToIndexSet(NSIndexSet(index: 1)))
+            XCTAssertEqual(buffer[2].0! as [NSObject], [3])
+            XCTAssertEqual(buffer[2].1 as NSKeyValueChange, NSKeyValueChange.Insertion)
+            XCTAssertTrue((buffer[2].2 as NSIndexSet).isEqualToIndexSet(NSIndexSet(index: 2)))
+            
+            dynamicArray.proxy.insertObject(0, atIndex: 0)
+            
+            XCTAssertEqual(dynamicArray.proxy, [0, 1, 2, 3])
+            XCTAssertEqual(obj1.array, dynamicArray.proxy)
+            XCTAssertEqual(buffer.count, 4)
+            XCTAssertEqual(buffer[3].0! as [NSObject], [0])
+            XCTAssertEqual(buffer[3].1 as NSKeyValueChange, NSKeyValueChange.Insertion)
+            XCTAssertTrue((buffer[3].2 as NSIndexSet).isEqualToIndexSet(NSIndexSet(index: 0)))
+            
+            dynamicArray.proxy.replaceObjectAtIndex(2, withObject: 2.5)
+            
+            XCTAssertEqual(dynamicArray.proxy, [0, 1, 2.5, 3])
+            XCTAssertEqual(obj1.array, dynamicArray.proxy)
+            XCTAssertEqual(buffer.count, 5)
+            XCTAssertEqual(buffer[4].0! as [NSObject], [2.5])
+            XCTAssertEqual(buffer[4].1 as NSKeyValueChange, NSKeyValueChange.Replacement)
+            XCTAssertTrue((buffer[4].2 as NSIndexSet).isEqualToIndexSet(NSIndexSet(index: 2)))
+            
+            dynamicArray.proxy.removeObjectAtIndex(2)
+            
+            XCTAssertEqual(dynamicArray.proxy, [0, 1, 3])
+            XCTAssertEqual(obj1.array, dynamicArray.proxy)
+            XCTAssertEqual(buffer.count, 6)
+            XCTAssertNil(buffer[5].0, "Deletion will send nil as changed value.")
+            XCTAssertEqual(buffer[5].1 as NSKeyValueChange, NSKeyValueChange.Removal)
+            XCTAssertTrue((buffer[5].2 as NSIndexSet).isEqualToIndexSet(NSIndexSet(index: 2)))
+            
+            expect.fulfill()
+            
+        }
+        
+        self.wait()
+    }
 }
 
 class AsyncArrayKVOTests: KVOTests


### PR DESCRIPTION
This pull request will add `DynamicArray` and `ForwardingDynamicArray` classes
which uses KVC's `mutableArrayValueForKey()` magic to interact with existing `NSArray` models.

### Example

#### DynamicArray

```
let dynamicArray = DynamicArray()

// REACT
dynamicArray.signal ~> { changedValues, change, indexSet in
    println(change)
}

// add object to proxy (NSMutableArray)
dynamicArray.proxy.addObject(123)

// `change = .Insertion` will be printed
```

#### ForwardingDynamicArray

```
let model = MyModel(array: [1])

// pass NSMutableArray so that `ForwardingDynamicArray` can tweak it
let dynamicArray = ForwardingDynamicArray(model.mutableArrayValueForKey("array"))

// REACT
dynamicArray.signal ~> { changedValues, change, indexSet in
    println(change)
}

// add object to proxy (NSMutableArray)
dynamicArray.proxy.addObject(2)

// `change = .Insertion` will be printed & `model.array` will be updated as `[1, 2]`
```

For XCTest, please see [ArrayKVOTests.swift#L224-L369](https://github.com/ReactKit/ReactKit/blob/1513f7c45ac61f12896a34c389a9c555f8a681e8/ReactKitTests/ArrayKVOTests.swift#L224-L369).

(UI example is coming soon)