### PR TITLE
Update SwiftTask to v3.1.0 & add Canceller feature.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactKit/SwiftTask" ~> 3.0.0
+github "ReactKit/SwiftTask" ~> 3.1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "duemunk/Async" "2f0c5b69e3ff0e41c9391016b7855cd319000515"
-github "ReactKit/SwiftTask" "3.0.0"
+github "ReactKit/SwiftTask" "3.1.0"

--- a/ReactKit/Foundation/KVO.swift
+++ b/ReactKit/Foundation/KVO.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import SwiftTask
 
 // NSNull-to-nil converter for KVO which returns NSNull when nil is set
 // https://github.com/ReactKit/ReactKit/pull/18
@@ -200,24 +201,29 @@ extension NSKeyValueChange: Printable
 infix operator <~ { associativity right }
 
 /// Key-Value Binding
-/// e.g. (obj2, "value") <~ stream
-public func <~ <T: AnyObject>(tuple: (object: NSObject, keyPath: String), stream: Stream<T?>)
+/// e.g. `(obj2, "value") <~ stream`
+public func <~ <T: AnyObject>(tuple: (object: NSObject, keyPath: String), stream: Stream<T?>) -> Canceller?
 {
     weak var object = tuple.object
     let keyPath = tuple.keyPath
+    var canceller: Canceller? = nil
     
-    stream.react { value in
+    stream.react(&canceller) { value in
         if let object = object {
             object.setValue(value, forKeyPath:keyPath)  // NOTE: don't use `tuple` inside closure, or object will be captured
         }
     }
+    
+    return canceller
 }
 
 /// Multiple Key-Value Binding
-/// e.g. [ (obj1, "value1"), (obj2, "value2") ] <~ stream (sending [value1, value2] array)
-public func <~ <T: AnyObject>(tuples: [(object: NSObject, keyPath: String)], stream: Stream<[T?]>)
+/// e.g. `[ (obj1, "value1"), (obj2, "value2") ] <~ stream` (sending [value1, value2] array)
+public func <~ <T: AnyObject>(tuples: [(object: NSObject, keyPath: String)], stream: Stream<[T?]>) -> Canceller?
 {
-    stream.react { (values: [T?]) in
+    var canceller: Canceller? = nil
+    
+    stream.react(&canceller) { (values: [T?]) in
         for i in 0..<tuples.count {
             if i >= values.count { break }
             
@@ -227,6 +233,8 @@ public func <~ <T: AnyObject>(tuples: [(object: NSObject, keyPath: String)], str
             tuple.object.setValue(value, forKeyPath:tuple.keyPath)
         }
     }
+    
+    return canceller
 }
 
 /// short-living Key-Value Binding


### PR DESCRIPTION
This pull request will improve overall performance by **using `Canceller` to invalidate stream-pipelining one-by-one** rather than `stream.cancel()`-ing all broadcasting pipelines.

`Canceller` works similar to `Rx.Disposable`, so when downstream deallocates, it can now clean up all handlers registered to its upstream.

For more information, please see https://github.com/ReactKit/SwiftTask/pull/31.

### Breaking Change

```
public func <~ <T>(reactClosure: T -> Void, stream: Stream<T>) -> Stream<T>
```

will now change its returning value as:

```
public func <~ <T>(reactClosure: T -> Void, stream: Stream<T>) -> Canceller?
```