### PR TITLE
Add startAsync(), async(), asyncBackpressureBlock()

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactKit/SwiftTask" ~> 3.1.0
+github "ReactKit/SwiftTask" ~> 3.2.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "duemunk/Async" "2f0c5b69e3ff0e41c9391016b7855cd319000515"
-github "ReactKit/SwiftTask" "3.1.0"
+github "ReactKit/SwiftTask" "3.2.0"

--- a/ReactKit.xcodeproj/project.pbxproj
+++ b/ReactKit.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		1F822EF419D319FF00A3CA23 /* _MyObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F822EF219D319FF00A3CA23 /* _MyObject.swift */; };
 		1F8C3AAB1A2D8614000D9CF8 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8C3AAA1A2D8614000D9CF8 /* Error.swift */; };
 		1F8C3AAC1A2D8614000D9CF8 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8C3AAA1A2D8614000D9CF8 /* Error.swift */; };
+		1F9D13811B0EB30100AED1CA /* AsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9D13801B0EB30100AED1CA /* AsyncTests.swift */; };
+		1F9D13821B0EB30100AED1CA /* AsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9D13801B0EB30100AED1CA /* AsyncTests.swift */; };
 		1FC50FF31AB9DA5400F363CD /* ImmediateSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC50FF21AB9DA5400F363CD /* ImmediateSequenceTests.swift */; };
 		1FC50FF41AB9DA5400F363CD /* ImmediateSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC50FF21AB9DA5400F363CD /* ImmediateSequenceTests.swift */; };
 		1FE9FFE81B0EAD1400757010 /* SyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE9FFE71B0EAD1400757010 /* SyncTests.swift */; };
@@ -77,6 +79,7 @@
 		1F822EE619D319E000A3CA23 /* CustomOperatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomOperatorTests.swift; sourceTree = "<group>"; };
 		1F822EF219D319FF00A3CA23 /* _MyObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _MyObject.swift; sourceTree = "<group>"; };
 		1F8C3AAA1A2D8614000D9CF8 /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
+		1F9D13801B0EB30100AED1CA /* AsyncTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncTests.swift; sourceTree = "<group>"; };
 		1FC50FF21AB9DA5400F363CD /* ImmediateSequenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImmediateSequenceTests.swift; sourceTree = "<group>"; };
 		1FE9FFE71B0EAD1400757010 /* SyncTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncTests.swift; sourceTree = "<group>"; };
 		1FED88F819C1EB120065658B /* ReactKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -226,6 +229,7 @@
 				1F44E4391ACAD0DF00B8428A /* StreamProducerTests.swift */,
 				48F5CE3B1ACCCAD800608038 /* TypeCastTests.swift */,
 				1FE9FFE71B0EAD1400757010 /* SyncTests.swift */,
+				1F9D13801B0EB30100AED1CA /* AsyncTests.swift */,
 				1FED890819C1EB120065658B /* Supporting Files */,
 			);
 			path = ReactKitTests;
@@ -442,6 +446,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1F2BEB601AAAB3A500256A58 /* ArrayKVOTests.swift in Sources */,
+				1F9D13811B0EB30100AED1CA /* AsyncTests.swift in Sources */,
 				1F626D9019D8799600D3ABCE /* CustomOperatorTests.swift in Sources */,
 				1FE9FFE81B0EAD1400757010 /* SyncTests.swift in Sources */,
 				1FC50FF31AB9DA5400F363CD /* ImmediateSequenceTests.swift in Sources */,
@@ -484,6 +489,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1F2BEB611AAAB3A500256A58 /* ArrayKVOTests.swift in Sources */,
+				1F9D13821B0EB30100AED1CA /* AsyncTests.swift in Sources */,
 				1F626D9419D8799900D3ABCE /* CustomOperatorTests.swift in Sources */,
 				1FE9FFE91B0EAD1400757010 /* SyncTests.swift in Sources */,
 				1FC50FF41AB9DA5400F363CD /* ImmediateSequenceTests.swift in Sources */,

--- a/ReactKit/Foundation/KVO.swift
+++ b/ReactKit/Foundation/KVO.swift
@@ -64,6 +64,8 @@ public extension NSObject
                 configure.pause = { observer.stop() }
                 configure.resume = { observer.start() }
                 configure.cancel = { observer.stop() }
+                
+                configure.resume?()
             }
             
         }.name("KVO.detailedStream(\(NSStringFromClass(self.dynamicType)), \"\(keyPath)\")") |> takeUntil(self.deinitStream)

--- a/ReactKit/Foundation/NSTimer+Stream.swift
+++ b/ReactKit/Foundation/NSTimer+Stream.swift
@@ -39,6 +39,8 @@ public extension NSTimer
                 timer = nil
             }
             
+            configure.resume?()
+            
         }.name("\(NSStringFromClass(self))")
     }
 }

--- a/ReactKit/Foundation/Notification.swift
+++ b/ReactKit/Foundation/Notification.swift
@@ -43,6 +43,8 @@ public extension NSNotificationCenter
                 }
             }
             
+            configure.resume?()
+            
         }.name("NSNotification-\(notificationName)") |> takeUntil(self.deinitStream)
     }
 }

--- a/ReactKit/UIKit/UIBarButtonItem+Stream.swift
+++ b/ReactKit/UIKit/UIBarButtonItem+Stream.swift
@@ -42,6 +42,8 @@ public extension UIBarButtonItem
                 removeTargetAction()
             }
             
+            configure.resume?()
+            
         }.name("\(NSStringFromClass(self.dynamicType))") |> takeUntil(self.deinitStream)
     }
     

--- a/ReactKit/UIKit/UIControl+Stream.swift
+++ b/ReactKit/UIKit/UIControl+Stream.swift
@@ -52,6 +52,8 @@ public extension UIControl
                 }
             }
             
+            configure.resume?()
+            
         }.name("\(NSStringFromClass(self.dynamicType))-\(controlEvents)") |> takeUntil(self.deinitStream)
     }
 }

--- a/ReactKit/UIKit/UIGestureRecognizer+Stream.swift
+++ b/ReactKit/UIKit/UIGestureRecognizer+Stream.swift
@@ -35,6 +35,8 @@ public extension UIGestureRecognizer
                 }
             }
             
+            configure.resume?()
+            
         }.name("\(NSStringFromClass(self.dynamicType))") |> takeUntil(self.deinitStream)
     }
 }

--- a/ReactKitTests/AsyncTests.swift
+++ b/ReactKitTests/AsyncTests.swift
@@ -1,0 +1,194 @@
+//
+//  AsyncTests.swift
+//  ReactKit
+//
+//  Created by Yasuhiro Inami on 2015/05/23.
+//  Copyright (c) 2015年 Yasuhiro Inami. All rights reserved.
+//
+
+import ReactKit
+import SwiftTask
+import Async
+import XCTest
+
+
+class AsyncTests: _TestCase
+{
+    override var isAsync: Bool { return true }
+    
+    func testStartAsync()
+    {
+        let expect = self.expectationWithDescription(__FUNCTION__)
+        
+        let mainQueue = dispatch_get_main_queue()
+        let queue0 = dispatch_queue_create("queue0", DISPATCH_QUEUE_SERIAL)
+        let queue1 = dispatch_queue_create("queue1", DISPATCH_QUEUE_SERIAL)
+        
+        var count = 0
+        let n = 100
+        
+        let upstream = Stream.sequence(1...n)
+        let downstream = upstream |> startAsync(queue1)
+        
+        println("*** Start ***")
+        
+        // starting from queue0
+        dispatch_async(queue0) {
+            // REACT
+            downstream ~> { value in
+                count++
+                XCTAssertTrue(_isCurrentQueue(queue1), "Must be queue1 thread.")
+                
+                NSLog("[sink] value = \(value), \(NSThread.currentThread())")
+                
+                if value == n {
+                    expect.fulfill()
+                }
+            }
+        }
+        
+        self.wait()
+        
+        XCTAssertEqual(count, n)
+    }
+    
+    func testAsync()
+    {
+        let expect = self.expectationWithDescription(__FUNCTION__)
+        
+        let mainQueue = dispatch_get_main_queue()
+        let queue0 = dispatch_queue_create("queue0", DISPATCH_QUEUE_SERIAL)
+        let queue1 = dispatch_queue_create("queue1", DISPATCH_QUEUE_SERIAL)
+        
+        let n = 100
+        var count: Int = 0
+        
+        let upstream = Stream.sequence(1...n)
+        let downstream = upstream |> async(queue1)
+        
+        println("*** Start ***")
+        
+        // starting from queue0
+        dispatch_async(queue0) {
+            // REACT
+            downstream ~> { value in
+                count++
+                XCTAssertTrue(_isCurrentQueue(queue1), "Must be queue1 thread.")
+                
+                NSLog("[sink] value = \(value), \(NSThread.currentThread())")
+                
+                if value == n {
+                    expect.fulfill()
+                }
+            }
+        }
+        
+        self.wait()
+            
+        XCTAssertEqual(count, n)
+    }
+    
+    func testBoth_startAsync_async()
+    {
+        let expect = self.expectationWithDescription(__FUNCTION__)
+        
+        let mainQueue = dispatch_get_main_queue()
+        let queue0 = dispatch_queue_create("queue0", DISPATCH_QUEUE_SERIAL)
+        let queue1 = dispatch_queue_create("queue1", DISPATCH_QUEUE_SERIAL)
+        let queue2 = dispatch_queue_create("queue2", DISPATCH_QUEUE_SERIAL)
+        
+        let n = 100
+        let consumerDelay = 0.1 // slow consumer test
+        var count: Int = 0
+        let lock = NSRecursiveLock()
+        
+        let upstream = Stream.sequence(1...n)
+        let downstream = upstream
+            |> startAsync(queue1)
+            |> peek { value in
+                lock.lock(); count++; lock.unlock();    // count up
+                XCTAssertTrue(_isCurrentQueue(queue1), "Must be queue1 thread.")
+                
+                NSLog("[peek1] value = \(value), \(NSThread.currentThread())")
+            }
+            |> async(queue2)
+            |> peek { value in
+                lock.lock(); count++; lock.unlock();    // count up
+                XCTAssertTrue(_isCurrentQueue(queue2), "Must be queue2 thread.")
+                
+                NSLog("[peek2] value = \(value), \(NSThread.currentThread())")
+            }
+        
+        println("*** Start ***")
+        
+        // starting from queue0
+        dispatch_async(queue0) {
+            // REACT
+            downstream ~> { value in
+                lock.lock(); count++; lock.unlock();    // count up
+                XCTAssertTrue(_isCurrentQueue(queue2), "Must be queue2 thread.")
+                
+                NSLog("[sink] value = \(value), \(NSThread.currentThread())")
+                
+                // sleep for simulating slow consumer
+//                NSThread.sleepForTimeInterval(consumerDelay)
+                
+                if value == n {
+                    expect.fulfill()
+                }
+            }
+        }
+        
+        self.wait(until: consumerDelay*Double(n)+1)
+        
+        XCTAssertEqual(count, 3*n)
+    }
+    
+    func testAsyncBackpressureBlock()
+    {
+        let expect = self.expectationWithDescription(__FUNCTION__)
+        
+        let mainQueue = dispatch_get_main_queue()
+        let queue0 = dispatch_queue_create("queue0", DISPATCH_QUEUE_SERIAL)
+        let queue1 = dispatch_queue_create("queue1", DISPATCH_QUEUE_SERIAL)
+        
+        let n = 100
+        let consumerDelay = 0.01 // 0.1 // slow consumer test
+        var count: Int = 0
+        let lock = NSRecursiveLock()
+        
+        let upstream = Stream.sequence(1...n)
+        let downstream = upstream
+            |> peek { value in
+                lock.lock(); count++; lock.unlock();    // count up
+                XCTAssertTrue(_isCurrentQueue(queue0), "Must be queue1 thread.")
+                
+                NSLog("[peek1] value = \(value), \(NSThread.currentThread())")
+            }
+            |> asyncBackpressureBlock(queue1, high: 5, low: 1)
+        
+        println("*** Start ***")
+        
+        // starting from queue0
+        dispatch_async(queue0) {
+            // REACT
+            downstream ~> { value in
+                lock.lock(); count++; lock.unlock();    // count up
+                XCTAssertTrue(_isCurrentQueue(queue1), "Must be queue1 thread.")
+                
+                NSLog("[sink] value = \(value), \(NSThread.currentThread())")
+                
+                // sleep for simulating slow consumer
+                NSThread.sleepForTimeInterval(consumerDelay)
+                
+                if value == n {
+                    expect.fulfill()
+                }
+            }
+        }
+        
+        self.wait(until: consumerDelay*Double(n)+1)
+        
+        XCTAssertEqual(count, 2*n)
+    }
+}

--- a/ReactKitTests/_TestCase.swift
+++ b/ReactKitTests/_TestCase.swift
@@ -13,7 +13,7 @@ typealias ErrorString = String
 
 class _TestCase: XCTestCase
 {
-    var timeInterval: NSTimeInterval = 0.0
+    var performAfter: NSTimeInterval = 0.0
     
     var isAsync: Bool { return false }
     
@@ -31,19 +31,19 @@ class _TestCase: XCTestCase
     
     func perform(after: NSTimeInterval = 0.01, closure: Void -> Void)
     {
-        self.timeInterval = after
+        self.performAfter = after
         
         if self.isAsync {
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(1_000_000_000 * self.timeInterval)), dispatch_get_main_queue(), closure)
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(1_000_000_000 * self.performAfter)), dispatch_get_main_queue(), closure)
         }
         else {
             closure()
         }
     }
     
-    func wait(filename: String = __FILE__, functionName: String = __FUNCTION__, line: Int = __LINE__)
+    func wait(until: NSTimeInterval = 1.0, filename: String = __FILE__, functionName: String = __FUNCTION__, line: Int = __LINE__)
     {
-        self.waitForExpectationsWithTimeout(self.timeInterval + 1) { error in
+        self.waitForExpectationsWithTimeout(self.performAfter + until) { error in
             if let error = error {
                 println()
                 println("*** Wait Error ***")
@@ -53,4 +53,9 @@ class _TestCase: XCTestCase
             }
         }
     }
+}
+
+func _isCurrentQueue(queue: dispatch_queue_t) -> Bool
+{
+    return dispatch_queue_get_label(queue) == dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL)
 }


### PR DESCRIPTION
This pull request will add `startAsync()`/`async()` (Rx's `subscribeOn()`/`observeOn()`) operations,
with directly using GCD's `dispatch_queue` as parameters instead of wrapped Scheduler classes.

Also, I added backpressure-able `asyncBackpressureBlock()` as an experiment.
Please note that this operation is very limited in usage, and can easily cause to deadlock, so be careful.

### ADDED

- [x] startAsync (a.k.a `Rx.subscribeOn()`)
- [x] async (a.k.a `Rx.observeOn()`)
- [x] asyncBackpressureBlock